### PR TITLE
Update Camus tests to work with new wrapper scripts required by thin-jar packaging.

### DIFF
--- a/ducttape/services/core.py
+++ b/ducttape/services/core.py
@@ -98,7 +98,7 @@ class KafkaService(Service):
                         'replication': settings.get('replication-factor', 1)
                     }
 
-                if settings["configs"] is not None:
+                if settings.get("configs") is not None:
                     for config_name, config_value in settings["configs"].items():
                         cmd += " --config %s=%s" % (config_name, str(config_value))
 
@@ -491,7 +491,7 @@ class HadoopV2Service(HDFSService):
         }
         mapred_site = mapred_site_template % mapred_site_params
 
-        yarn_env_template = open('templates/hadoop-env.sh').read()
+        yarn_env_template = open('templates/yarn-env.sh').read()
         yarn_env_params = {
             'java_home': '/usr/lib/jvm/java-6-oracle'
         }


### PR DESCRIPTION
As a side effect, this also fixes the HadoopV1-backed tests to use the correct bin
directory and therefore fixes them so they run distributed as expected instead of
locally.

@Ishiihara I think it makes most sense for you to review this in combination with confluentinc/camus#10. If you have time, it would also be nice if you could merge with the hdp branch and test that -- you'll need to do some minor merge cleanup, but it's fairly clean and easy. I'd like to get this one merged ASAP since it also includes the fix for the v1 tests which weren't running the correct binary and were therefore running local V2 jobs instead of distributed v1 jobs. I think the hdp branch still needs cleanup and, as long as we test the merged version, isn't as urgent to merge ASAP.
