### PR TITLE
Verify input paths exist during test discovery.

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ducktape.tests.loader import TestLoader
+from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.runner import SerialTestRunner
 from ducktape.tests.reporter import SimpleStdoutReporter, SimpleFileReporter, HTMLReporter
 from ducktape.tests.session import SessionContext
@@ -81,7 +81,12 @@ def main():
 
     # Discover and load tests to be run
     loader = TestLoader(session_context)
-    test_classes = loader.discover(args.test_path)
+    try:
+        test_classes = loader.discover(args.test_path)
+    except LoaderException as e:
+        print "Failed while trying to discover tests: {}".format(e)
+        sys.exit(1)
+
     if args.collect_only:
         print test_classes
         sys.exit(0)

--- a/ducktape/tests/loader.py
+++ b/ducktape/tests/loader.py
@@ -19,6 +19,8 @@ import inspect
 import os
 import re
 
+class LoaderException(Exception):
+    pass
 
 class TestLoader(object):
     """Class used to discover and load tests."""
@@ -41,6 +43,8 @@ class TestLoader(object):
         test_classes = []
         assert type(test_discovery_symbols) == list, "Expected test_discovery_symbols to be a list."
         for symbol in test_discovery_symbols:
+            if not os.path.exists(symbol):
+                raise LoaderException("Path {} does not exist".format(symbol))
 
             if os.path.isfile(symbol):
                 test_files = [os.path.abspath(symbol)]

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -27,7 +27,7 @@ class TestRunner(object):
         self.results = TestResults(self.session_context)
         self.logger = session_context.logger
 
-        self.logger.debug("Instantiating %s" + self.__class__.__name__)
+        self.logger.debug("Instantiating " + self.__class__.__name__)
 
     def run_all_tests(self):
         raise NotImplementedError()

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ducktape.tests.loader import TestLoader
+from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.session import SessionContext
 
 import os
 import os.path
 import tempfile
+import pytest
 
 def discover_dir():
     """Return the absolute path to the directory to use with discovery tests."""
@@ -44,6 +45,11 @@ class CheckTestLoader(object):
         test_classes = loader.discover([os.path.join(discover_dir(), "test_a.py")])
         assert len(test_classes) == 1
 
+    def check_test_loader_with_nonexistent_file(self):
+        """Check discovery on a starting path that doesn't exist throws an"""
+        with pytest.raises(LoaderException):
+            loader = TestLoader(self.SESSION_CONTEXT)
+            test_classes = loader.discover([os.path.join(discover_dir(), "file_that_does_not_exist.py")])
 
 
 


### PR DESCRIPTION
Print an error and exit with a non-zero status code to indicate that the tests
failed since specifying a non-existent path is probably an error on the user's
part.