### PR TITLE
Service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ If you are are a ducktape developer, consider using the develop command instead 
 Running Tests
 -------------
 To run one or more tests, run
-`ducktape <relative_path_to_testfile>`
-`ducktape <relative_path_to_testdirectory>`
 
-ducktape will discover tests and run all tests that it finds. ducktape can take multiple test files and/or test directories
- as its arguments, and will discover and run tests from every path provided.
+    ducktape <relative_path_to_testfile>        # e.g. ducktape dir/tests/my_test.py
+    ducktape <relative_path_to_testdirectory>   # e.g. ducktape dir/tests
+    ducktape <path_to_test>[::SomeTestClass]    # e.g. ducktape dir/tests/my_test.py::TestA
+    ducktape [<test_path1> [<test_path2> ...]]  # e.g. ducktape dir/tests/my_test.py dir/tests/my_other_test.py::OtherTest
+
+ducktape will discover tests and run all tests that it finds. ducktape can take multiple test files and/or test directories as its arguments, and will discover and run tests from every path provided. To see what tests would be run without actuall running, use the `--collect-only` flag.
+
+    ducktape <path_to_testfile_or_directory> --collect-only
 
 Test Output
 -----------

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -163,10 +163,11 @@ class RemoteAccount(HttpMixin):
         try:
             subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            if allow_fail:
-                return
             self.logger.warn("Error running remote command: " + cmd)
             self.logger.warn(e.output)
+
+            if allow_fail:
+                return
             raise e
 
     def __str__(self):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -52,7 +52,6 @@ class RemoteAccount(HttpMixin):
                             "Either the service failed to start, or there is a problem with the url. "
                             "You may need to open Vagrantfile.local and add the line 'enable_dns = true'.")
 
-
     def ssh_command(self, cmd):
         r = "ssh "
         if self.user:
@@ -150,8 +149,8 @@ class RemoteAccount(HttpMixin):
         except subprocess.CalledProcessError as e:
             if allow_fail:
                 return
-            print "Error running remote command: " + cmd
-            print e.output
+            self.logger.warn("Error running remote command: " + cmd)
+            self.logger.warn(e.output)
             raise e
 
     def __str__(self):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -89,6 +89,14 @@ class RemoteAccount(HttpMixin):
             self.ssh(cmd, allow_fail)
 
     def scp_from_command(self, src, dest, recursive=False):
+        if type(src) == list:
+            if len(src) == 0:
+                src = ""
+            elif len(src) == 1:
+                src = src[0]
+            else:
+                src = "\{" + ",".join(src) + "\}"
+
         r = "scp "
         if self.ssh_args:
             r += self.ssh_args + " "
@@ -104,6 +112,14 @@ class RemoteAccount(HttpMixin):
         return self._ssh_quiet(self.scp_from_command(src, dest, recursive))
 
     def scp_to_command(self, src, dest, recursive=False):
+        if type(src) == list:
+            if len(src) == 0:
+                src = ""
+            elif len(src) == 1:
+                src = src[0]
+            else:
+                src = " ".join(src)
+
         r = "scp "
         if self.ssh_args:
             r += self.ssh_args + " "

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -31,7 +31,7 @@ class RemoteAccount(HttpMixin):
 
     @property
     def local(self):
-        "Returns true if this 'remote' account is actually local. This is only a heuristic, but should work for simple local testing."
+        """Returns true if this 'remote' account is actually local. This is only a heuristic, but should work for simple local testing."""
         return self.hostname == "localhost" and self.user is None and self.ssh_args is None
 
     def wait_for_http_service(self, port, headers, timeout=20, path='/'):
@@ -66,7 +66,7 @@ class RemoteAccount(HttpMixin):
         return self._ssh_quiet(self.ssh_command(cmd), allow_fail)
 
     def ssh_capture(self, cmd):
-        '''Runs the command via SSH and captures the output, yielding lines of the output.'''
+        """Runs the command via SSH and captures the output, yielding lines of the output."""
         ssh_cmd = self.ssh_command(cmd)
         proc = subprocess.Popen(ssh_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in iter(proc.stdout.readline, ''):
@@ -89,36 +89,35 @@ class RemoteAccount(HttpMixin):
             self.ssh(cmd, allow_fail)
 
     def scp_from_command(self, src, dest, recursive=False):
-        if type(src) == list:
-            if len(src) == 0:
-                src = ""
-            elif len(src) == 1:
-                src = src[0]
-            else:
-                src = "\{" + ",".join(src) + "\}"
+        if self.user:
+            remotehost = self.user + "@" + self.hostname
+        else:
+            remotehost = self.hostname
+
+        if isinstance(src, basestring):
+            src = remotehost + ":" + src
+        else:
+            # assume src is iterable
+            # e.g. "ubuntu@host:path1 ubuntu@host:path2"
+            src = " ".join([remotehost + ":" + path for path in src])
 
         r = "scp "
         if self.ssh_args:
             r += self.ssh_args + " "
         if recursive:
             r += "-r "
-        if self.user:
-            r += self.user + "@"
-        r += self.hostname + ":" + src + " " + dest
+
+        r += src + " " + dest
         return r
 
     def scp_from(self, src, dest, recursive=False):
-        """Copy something from this node."""
+        """Copy something from this node. src may be a string or an iterable of several sources."""
         return self._ssh_quiet(self.scp_from_command(src, dest, recursive))
 
     def scp_to_command(self, src, dest, recursive=False):
-        if type(src) == list:
-            if len(src) == 0:
-                src = ""
-            elif len(src) == 1:
-                src = src[0]
-            else:
-                src = " ".join(src)
+        if not isinstance(src, basestring):
+            # Assume src is iterable
+            src = " ".join(src)
 
         r = "scp "
         if self.ssh_args:
@@ -158,9 +157,10 @@ class RemoteAccount(HttpMixin):
         os.remove(local_name)
 
     def _ssh_quiet(self, cmd, allow_fail=False):
-        '''Runs the command on the remote host using SSH. If it succeeds, there is no
-        output; if it fails the output is printed and the CalledProcessError is re-raised.'''
+        """Runs the command on the remote host using SSH. If it succeeds, there is no
+        output; if it fails the output is printed and the CalledProcessError is re-raised."""
         try:
+            self.logger.debug("Trying to run remote command: " + cmd)
             subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             self.logger.warn("Error running remote command: " + cmd)

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -101,6 +101,7 @@ class RemoteAccount(HttpMixin):
         return r
 
     def scp_from(self, src, dest, recursive=False):
+        """Copy something from this node."""
         return self._ssh_quiet(self.scp_from_command(src, dest, recursive))
 
     def scp_to_command(self, src, dest, recursive=False):

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -68,7 +68,8 @@ class Service(object):
                     "or some service which isn't properly cleaning up after itself. " +
                     "Service: %s, node.account: %s" % (self.__class__.__name__, str(node.account)))
             node.account.set_logger(self.logger)
-            self.allocated = True
+
+        self.allocated = True
 
     def start(self):
         """Start the service on all nodes."""

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -12,23 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Service classes know how to deploy a service onto a set of nodes and then
-# clean up the services. They request the necessary resources from the cluster,
-# configure each server, and bring up/tear down the service. They also expose
-# information about the service so that other services or test scripts can
-# easily be configured to work with them. Finally, they may be able to collect
-# and check logs/output from the service, which can be helpful in writing tests
-# or benchmarks.
-#
-# Services should generally be written to support an arbitrary number of nodes,
-# even if instances are independent of each other. They should be able to assume
-# that there won't be resource conflicts: the cluster tests are being run on
-# should be large enough to use one instance per service instance.
+
 
 from ducktape.command_line.config import ConsoleConfig
 
 
 class Service(object):
+    """Service classes know how to deploy a service onto a set of nodes and then clean up after themselves.
+
+    They request the necessary resources from the cluster,
+    configure each node, and bring up/tear down the service.
+
+    They also expose
+    information about the service so that other services or test scripts can
+    easily be configured to work with them. Finally, they may be able to collect
+    and check logs/output from the service, which can be helpful in writing tests
+    or benchmarks.
+
+    Services should generally be written to support an arbitrary number of nodes,
+    even if instances are independent of each other. They should be able to assume
+    that there won't be resource conflicts: the cluster tests are being run on
+    should be large enough to use one instance per service instance.
+    """
+
     def __init__(self, service_context):
         """
         :type service_context: ServiceContext
@@ -37,9 +43,11 @@ class Service(object):
         self.cluster = service_context.cluster
         self.logger = service_context.logger
 
-    def start(self):
-        """Start the service running in the background."""
+    def allocate_nodes(self):
+        """Request resources from the cluster."""
+        self.logger.debug("Requesting nodes from the cluster.")
         self.nodes = self.cluster.request(self.num_nodes)
+
         for idx, node in enumerate(self.nodes, 1):
 
             # Remote accounts utilities should log where this service logs
@@ -52,21 +60,66 @@ class Service(object):
                     "Service: %s, node.account: %s" % (self.__class__.__name__, str(node.account)))
             node.account.set_logger(self.logger)
 
-            self.logger.debug("Forcibly cleaning node %d on %s", idx, node.account.hostname)
-            self._clean_node(node)
+    def start(self):
+        """Start the service on all nodes."""
+        for node in self.nodes:
+            # Added precaution - kill running processes
+            self.logger.debug("Forcibly killing running processes on node %d on %s", self.idx(node), node.account.hostname)
+            self._kill_running_processes(node)
+
+            self.stop_node(node)
+            self.clean_node(node)
+
+            self.start_node(node)
+            self.wait_until_alive(node)
+
+    def start_node(self, node):
+        """Start service process(es) on the given node."""
+        raise NotImplementedError("Subclasses must implement clean_node.")
+
+    def wait_until_alive(self, node):
+        """Wait until this service node is alive.
+        """
+        pass
 
     def wait(self):
-        """Wait for the service to finish. This only makes sense for tasks with a fixed
-        amount of work to do. For services that generate output, it is only
-        guaranteed to be available after this call returns.
+        """Wait for the service to finish.
+        This only makes sense for tasks with a fixed amount of work to do. For services that generate
+        output, it is only guaranteed to be available after this call returns.
         """
         pass
 
     def stop(self):
-        """If the service left any running processes or data, clean them up."""
-        for idx, node in enumerate(self.nodes, 1):
+        """Stop service processes on each node in this service.
+        Subclasses must override stop_node.
+        """
+        for node in self.nodes:
+            self.stop_node(node)
             node.account.set_logger(None)
 
+    def stop_node(self, node):
+        """Halt service process(es) on this node."""
+        raise NotImplementedError("Subclasses must implement stop_node.")
+
+    def clean(self):
+        """Clean up persistent state on each node - e.g. logs, config files etc.
+        Subclasses must override clean_node.
+        """
+        for node in self.nodes:
+            self.clean_node(node)
+
+    def clean_node(self, node):
+        """Clean up persistent state on this node - e.g. service logs, configuration files etc."""
+        raise NotImplementedError("Subclasses must implement clean_node.")
+
+    def free(self):
+        """Free each node. This 'deallocates' the nodes so the cluster can assign them to other services."""
+        for node in self.nodes:
+            self.free_node(node)
+
+    def free_node(self, node):
+        """Release this node back to the cluster that owns it."""
+        node.free()
 
     def run(self):
         """Helper that executes run(), wait(), and stop() in sequence."""
@@ -79,13 +132,16 @@ class Service(object):
         return self.nodes[idx - 1]
 
     def idx(self, node):
-        """Return id of the given node. Return -1 if node does not belong to this service. """
+        """Return id of the given node. Return -1 if node does not belong to this service.
+
+        idx identifies the node within this service instance (not globally).
+        """
         for idx, n in enumerate(self.nodes, 1):
             if self.get_node(idx) == node:
                 return idx
         return -1
 
-    def _clean_node(self, node):
+    def _kill_running_processes(self, node):
         """
         Helper that tries to kill off all running Java processes to make sure a node
         is in a clean state.

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 from ducktape.command_line.config import ConsoleConfig
 
 
@@ -76,16 +75,10 @@ class Service(object):
         for node in self.nodes:
             self.logger.debug("Starting node %d on %s" % (self.idx(node), node.account.hostname))
             self.start_node(node)
-            self.wait_until_alive(node)
 
     def start_node(self, node):
         """Start service process(es) on the given node."""
         raise NotImplementedError("Subclasses must implement clean_node.")
-
-    def wait_until_alive(self, node):
-        """Wait until this service node is alive.
-        """
-        pass
 
     def wait(self):
         """Wait for the service to finish.

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -62,14 +62,19 @@ class Service(object):
 
     def start(self):
         """Start the service on all nodes."""
+        self.logger.info("Starting service: %s" % self.__class__.__name__)
+
+        self.logger.debug("Killing processes and attempting to clean up before starting nodes.")
         for node in self.nodes:
             # Added precaution - kill running processes
-            self.logger.debug("Forcibly killing running processes on node %d on %s", self.idx(node), node.account.hostname)
             self._kill_running_processes(node)
 
             self.stop_node(node)
             self.clean_node(node)
 
+        self.logger.info("Starting nodes for %s " % self.__class__.__name__)
+        for node in self.nodes:
+            self.logger.debug("Starting node %d on %s" % (self.idx(node), node.account.hostname))
             self.start_node(node)
             self.wait_until_alive(node)
 

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -48,6 +48,16 @@ class Service(object):
         if hasattr(self.context, "services"):
             self.context.services.append(self)
 
+        # Provides a mechanism for locating and collecting log files produced by the service on its nodes.
+        # logs is a dict with entries that look like log_name: {"path": log_path, "collect_default": boolean}
+        #
+        # For example, zookeeper service might have self.logs like this:
+        # self.logs = {
+        #    "zk_log": {"path": "/mnt/zk.log",
+        #               "collect_default": True}
+        # }
+        self.logs = {}
+
     def allocate_nodes(self):
         """Request resources from the cluster."""
         if self.allocated:

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -58,6 +58,13 @@ class Service(object):
         # }
         self.logs = {}
 
+    def who_am_i(self, node=None):
+        """Human-readable identifier useful for log messages."""
+        if node is None:
+            return self.__class__.__name__
+        else:
+            return "%s node %d on %s" % (self.__class__.__name__, self.idx(node), node.account.hostname)
+
     def allocate_nodes(self):
         """Request resources from the cluster."""
         if self.allocated:
@@ -83,27 +90,26 @@ class Service(object):
 
     def start(self):
         """Start the service on all nodes."""
-        self.logger.info("Starting service: %s" % self.__class__.__name__)
+        self.logger.info("%s: starting service" % self.who_am_i())
 
         if not self.allocated:
             self.allocate_nodes()
 
-        self.logger.debug("Killing processes and attempting to clean up before starting nodes.")
+        self.logger.debug(self.who_am_i() + ": killing processes and attempting to clean up before starting")
         for node in self.nodes:
             # Added precaution - kill running processes
             self._kill_running_processes(node)
-
+            self.force_clean_node(node)
             self.stop_node(node)
             self.clean_node(node)
 
-        self.logger.info("Starting nodes for %s " % self.__class__.__name__)
         for node in self.nodes:
-            self.logger.debug("Starting node %d on %s" % (self.idx(node), node.account.hostname))
+            self.logger.debug("%s: starting node" % self.who_am_i(node))
             self.start_node(node)
 
     def start_node(self, node):
         """Start service process(es) on the given node."""
-        raise NotImplementedError("Subclasses must implement start_node.")
+        raise NotImplementedError("%s: subclasses must implement start_node." % self.who_am_i())
 
     def wait(self):
         """Wait for the service to finish.
@@ -116,28 +122,64 @@ class Service(object):
         """Stop service processes on each node in this service.
         Subclasses must override stop_node.
         """
+        self.logger.info("%s: stopping service" % self.who_am_i())
         for node in self.nodes:
+            self.logger.info("%s: stopping node" % self.who_am_i(node))
             self.stop_node(node)
 
     def stop_node(self, node):
         """Halt service process(es) on this node."""
-        raise NotImplementedError("Subclasses must implement stop_node.")
+        raise NotImplementedError("%s: subclasses must implement stop_node." % self.who_am_i())
 
     def clean(self):
         """Clean up persistent state on each node - e.g. logs, config files etc.
         Subclasses must override clean_node.
         """
+        self.logger.info("%s: cleaning service" % self.who_am_i())
         for node in self.nodes:
+            self.logger.info("%s: cleaning node" % self.who_am_i(node))
             self.clean_node(node)
+
+    def force_clean_node(self, node):
+        self.logger.info("%s: recklessly cleaning leftover files on node" % self.who_am_i(node))
+        node.account.ssh("rm -rf /mnt/*", allow_fail=True)
 
     def clean_node(self, node):
         """Clean up persistent state on this node - e.g. service logs, configuration files etc."""
-        self.logger.warn("clean_node has not been overriden. " +
+        self.logger.warn("%s: clean_node has not been overriden. " % self.who_am_i(),
                          "This may be fine if the service leaves no persistent state.")
+
+    def check_clean(self):
+        """Check that there is no leftover persistent state.
+
+        This is an imperfect check, but can provide early warning for service developers.
+        """
+        self.logger.debug("%s: checking that there are no stray files left by this or other services" % self.who_am_i())
+        clean = True
+        for node in self.nodes:
+            clean = clean and self.check_clean_node(node)
+        return clean
+
+    def check_clean_node(self, node):
+        """Rule-of-thumb to verify that the service properly cleaned up after itself.
+
+        /mnt is the defacto standard for where to place files, so simply check that this is empty.
+        """
+        self.logger.debug("%s: checking for cleanliness" % self.who_am_i(node))
+        lines = [line.strip() for line in node.account.ssh_capture("for f in `ls /mnt`; do echo `pwd`/$f; done") if len(line.strip()) > 0]
+        if len(lines) == 0:
+            self.logger.debug("%s: appears clean", self.who_am_i(node))
+            return True
+        else:
+            self.logger.debug("%s: unclean!!", self.who_am_i(node))
+            self.logger.debug("Found these files: %s. %s or another service may not have properly cleaned up after itself.",
+                              lines, self.who_am_i())
+            return False
 
     def free(self):
         """Free each node. This 'deallocates' the nodes so the cluster can assign them to other services."""
         for node in self.nodes:
+            self.logger.info("%s: freeing node" % self.who_am_i(node))
             node.account.set_logger(None)
             self.free_node(node)
 

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -22,57 +22,26 @@ import os
 
 class ServiceRegistry(OrderedDict):
 
+    def allocate_nodes(self):
+        """Make all registered services request nodes from the cluster."""
+        for service in self.values():
+            service.allocate_nodes()
+
     def start_all(self):
         """Start all currently registered services in the same order in which they were added."""
         for service in self.values():
             service.start()
 
     def stop_all(self):
-        """Stop all currently registered services in the reverse of the order in which they were added."""
+        """Stop all currently registered services in the reverse of the order in which they were added.
+
+        Note that this does not clean up persistent state or free the nodes back to the cluster.
+        """
         for service in reversed(self.values()):
             try:
                 service.stop()
             except Exception as e:
-                service.logger.debug("Error stopping service %s: %s" % (service, e.message))
-
-    def pull_logs(self, service_name, test_context):
-        """Pull logs from service. Service can be service name or the original service object.
-
-        :type service_name: str
-        :type test_context: ducktape.tests.test.TestContext
-        """
-        service = self[service_name]
-
-        if not hasattr(service, 'logs'):
-            test_context.logger.debug("Won't collect service logs from %s - no 'logs' attribute." %
-                service.__class__.__name__)
-
-        log_dirs = service.logs
-
-        for node in service.nodes:
-            for log_name in log_dirs.keys():
-                if self.should_collect_log(log_name, service_name, node):
-                    dest = os.path.join(test_context.results_dir, service.__class__.__name__, node.account.hostname)
-                    if os.path.isfile(dest):
-                        pass # error!
-
-                    if not os.path.isdir(dest):
-                        mkdir_p(dest)
-
-                    try:
-                        node.account.scp_from(log_dirs[log_name], dest, recursive=True)
-                    except Exception as e:
-                        test_context.logger.warn(
-                            "Error copying log %(log_name)s from %(source)s to %(dest)s. \
-                            service %(service)s: %(message)s" %
-                            {'log_name': log_name,
-                             'source': log_dirs[log_name],
-                             'dest': dest,
-                             'service': service,
-                             'message': e.message})
-
-    def should_collect_log(self, log_name, service, node):
-        return True
+                service.logger.warn("Error stopping service %s: %s" % (service, e.message))
 
     def clean_all(self):
         """Clean all services. This should only be called after services are stopped."""
@@ -80,7 +49,7 @@ class ServiceRegistry(OrderedDict):
             try:
                 service.clean()
             except Exception as e:
-                service.logger.debug("Error cleaning service %s: %s" % (service, e.message))
+                service.logger.warn("Error cleaning service %s: %s" % (service, e.message))
 
     def free_all(self):
         """Release nodes back to the cluster."""
@@ -88,4 +57,7 @@ class ServiceRegistry(OrderedDict):
             try:
                 service.free()
             except Exception as e:
-                service.logger.debug("Error cleaning service %s: %s" % (service, e.message))
+                service.logger.warn("Error cleaning service %s: %s" % (service, e.message))
+
+    def num_nodes(self):
+        return sum([service.num_nodes for service in self.values()])

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -20,24 +20,14 @@ from collections import OrderedDict
 import os
 
 
-class ServiceRegistry(OrderedDict):
-
-    def allocate_nodes(self):
-        """Make all registered services request nodes from the cluster."""
-        for service in self.values():
-            service.allocate_nodes()
-
-    def start_all(self):
-        """Start all currently registered services in the same order in which they were added."""
-        for service in self.values():
-            service.start()
+class ServiceRegistry(list):
 
     def stop_all(self):
         """Stop all currently registered services in the reverse of the order in which they were added.
 
         Note that this does not clean up persistent state or free the nodes back to the cluster.
         """
-        for service in reversed(self.values()):
+        for service in reversed(self):
             try:
                 service.stop()
             except BaseException as e:
@@ -45,7 +35,7 @@ class ServiceRegistry(OrderedDict):
 
     def clean_all(self):
         """Clean all services. This should only be called after services are stopped."""
-        for service in self.values():
+        for service in self:
             try:
                 service.clean()
             except BaseException as e:
@@ -53,11 +43,11 @@ class ServiceRegistry(OrderedDict):
 
     def free_all(self):
         """Release nodes back to the cluster."""
-        for service in self.values():
+        for service in self:
             try:
                 service.free()
             except BaseException as e:
                 service.logger.warn("Error cleaning service %s: %s" % (service, e.message))
 
     def num_nodes(self):
-        return sum([service.num_nodes for service in self.values()])
+        return sum([service.num_nodes for service in self])

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -1,0 +1,72 @@
+# Copyright 2014 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.services.service import Service
+
+from collections import OrderedDict
+
+
+class ServiceRegistry(OrderedDict):
+
+    def start_all(self):
+        """Start all currently registered services in the same order in which they were added."""
+        for service in self.values():
+            service.start()
+
+    def stop_all(self):
+        """Stop all currently registered services in the reverse of the order in which they were added."""
+        for service in reversed(self.values()):
+            try:
+                service.stop()
+            except Exception as e:
+                service.logger.debug("Error stopping service %s: %s" % (service, e.message))
+
+    def pull_logs(self, service_name, destination_directory):
+        """Pull logs from service. Service can be service name or the original service object."""
+        service = self[service_name]
+        log_directories = service.logs
+
+        for node in service.nodes:
+            for log_name in log_directories.keys():
+                if self.should_collect_log(log_name, service_name, node):
+                    try:
+                        node.account.scp_from(log_directories[log_name], destination_directory, recursive=True)
+                    except Exception as e:
+                        service.logger.debug(
+                            "Error copying log %(log_name)s from %(source)s to %(dest)s. \
+                            service %(service)s: %(message)s" %
+                            {'log_name': log_name,
+                             'source': log_directories[log_name],
+                             'dest': destination_directory,
+                             'service': service,
+                             'message': e.message})
+
+    def should_collect_log(self, log_name, service, node):
+        return True
+
+    def clean_all(self):
+        """Clean all services. This should only be called after services are stopped."""
+        for service in self.values():
+            try:
+                service.clean()
+            except Exception as e:
+                service.logger.debug("Error cleaning service %s: %s" % (service, e.message))
+
+    def free_all(self):
+        """Release nodes back to the cluster."""
+        for service in self.values():
+            try:
+                service.free()
+            except Exception as e:
+                service.logger.debug("Error cleaning service %s: %s" % (service, e.message))

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -38,6 +38,8 @@ class ServiceRegistry(list):
         for service in self:
             try:
                 service.clean()
+                if not service.check_clean():
+                    service.logger.warn("%s cleanup may be incomplete" % service.who_am_i())
             except BaseException as e:
                 service.logger.warn("Error cleaning service %s: %s" % (service, e.message))
 

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -40,7 +40,7 @@ class ServiceRegistry(OrderedDict):
         for service in reversed(self.values()):
             try:
                 service.stop()
-            except Exception as e:
+            except BaseException as e:
                 service.logger.warn("Error stopping service %s: %s" % (service, e.message))
 
     def clean_all(self):
@@ -48,7 +48,7 @@ class ServiceRegistry(OrderedDict):
         for service in self.values():
             try:
                 service.clean()
-            except Exception as e:
+            except BaseException as e:
                 service.logger.warn("Error cleaning service %s: %s" % (service, e.message))
 
     def free_all(self):
@@ -56,7 +56,7 @@ class ServiceRegistry(OrderedDict):
         for service in self.values():
             try:
                 service.free()
-            except Exception as e:
+            except BaseException as e:
                 service.logger.warn("Error cleaning service %s: %s" % (service, e.message))
 
     def num_nodes(self):

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -36,9 +36,11 @@ class SimpleReporter(TestReporter):
     def header_string(self):
         """Header lines of the report"""
         header_lines = [
+            "=========================================================================",
             "Test run with session_id " + self.results.session_context.session_id,
             self.pass_fail(self.results.get_aggregate_success()),
-            "---------------------------------------------------------------------"
+            "==========================="
+
             ]
 
         return "\n".join(header_lines)
@@ -54,6 +56,8 @@ class SimpleReporter(TestReporter):
 
         if result.data is not None:
             result_lines.append(json.dumps(result.data))
+
+        result_lines.append("===========================")
 
         return "\n".join(result_lines)
 

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -40,8 +40,7 @@ class SimpleReporter(TestReporter):
             "Test run with session_id " + self.results.session_context.session_id,
             self.pass_fail(self.results.get_aggregate_success()),
             "==========================="
-
-            ]
+        ]
 
         return "\n".join(header_lines)
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -71,7 +71,7 @@ class SerialTestRunner(TestRunner):
         try:
             # Obtain nodes from the cluster
             self.logger.info(self.__class__.__name__ + ": allocating nodes for " + test.__class__.__name__)
-            test.services.allocate_nodes()
+            test.allocate_nodes()
             self.logger.info((self.__class__.__name__ + ": allocated %d nodes for %s " %
                               (test.services.num_nodes(), test.__class__.__name__)))
 
@@ -89,6 +89,7 @@ class SerialTestRunner(TestRunner):
             if hasattr(test, 'tearDown'):
                 self.logger.info(self.__class__.__name__ + ": tearing down " + test.__class__.__name__)
                 test.tearDown()
+                test.free_nodes()
 
 
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -49,9 +49,7 @@ class SerialTestRunner(TestRunner):
         for test in self.tests:
             result = TestResult(self.session_context, str(test))
             try:
-                self.run_test(test)
-
-                # some mechanism for collecting summary and/or test data (json?)
+                self.run_single_test(test)
             except Exception as e:
                 result.success = False
                 result.summary += e.message + "\n" + traceback.format_exc(limit=16) + "\n"
@@ -60,18 +58,26 @@ class SerialTestRunner(TestRunner):
 
         return self.results
 
-    def run_test(self, test_class):
+    def run_single_test(self, test_class):
         test = get_test_case(test_class, self.session_context)
         self.logger.debug("Instantiated test class: " + str(test))
 
+        self.logger.debug("Checking if there are enough nodes...")
         if test.min_cluster_size() > self.cluster.num_available_nodes():
             raise RuntimeError(
                 "There are not enough nodes available in the cluster to run this test. Needed: %d, Available: %d" %
                 (test.min_cluster_size(), self.cluster.num_available_nodes()))
 
         try:
+            # Obtain nodes from the cluster
+            self.logger.info(self.__class__.__name__ + ": allocating nodes for " + test.__class__.__name__)
+            test.services.allocate_nodes()
+            self.logger.info((self.__class__.__name__ + ": allocated %d nodes for %s " %
+                              (test.services.num_nodes(), test.__class__.__name__)))
+
             if hasattr(test, 'setUp'):
                 self.logger.info(self.__class__.__name__ + ": setting up " + test.__class__.__name__)
+                # start services etc
                 test.setUp()
 
             self.logger.info(self.__class__.__name__ + ": running " + test.__class__.__name__)

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -50,7 +50,7 @@ class SerialTestRunner(TestRunner):
             result = TestResult(self.session_context, str(test))
             try:
                 self.run_single_test(test)
-            except Exception as e:
+            except BaseException as e:
                 result.success = False
                 result.summary += e.message + "\n" + traceback.format_exc(limit=16) + "\n"
             finally:
@@ -77,7 +77,7 @@ class SerialTestRunner(TestRunner):
             self.logger.info(self.__class__.__name__ + ": running " + test.__class__.__name__)
             test.run()
             self.logger.info(self.__class__.__name__ + ": successfully ran " + test.__class__.__name__)
-        except Exception as e:
+        except BaseException as e:
             raise
         finally:
             if hasattr(test, 'tearDown'):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -69,12 +69,6 @@ class SerialTestRunner(TestRunner):
                 (test.min_cluster_size(), self.cluster.num_available_nodes()))
 
         try:
-            # Obtain nodes from the cluster
-            self.logger.info(self.__class__.__name__ + ": allocating nodes for " + test.__class__.__name__)
-            test.allocate_nodes()
-            self.logger.info((self.__class__.__name__ + ": allocated %d nodes for %s " %
-                              (test.services.num_nodes(), test.__class__.__name__)))
-
             if hasattr(test, 'setUp'):
                 self.logger.info(self.__class__.__name__ + ": setting up " + test.__class__.__name__)
                 # start services etc

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -26,24 +26,26 @@ class SessionContext(Logger):
     which helps route logging and reporting, etc.
     """
 
-    def __init__(self, session_id, results_dir, cluster, log_config=None):
+    def __init__(self, session_id, results_dir, cluster, debug=False):
         """
         :type session_id: str   Global session identifier
         :type results_dir: str  All test results go here
         :type cluster: ducktape.cluster.cluster.Cluster
+        :type debug: boolean    Signals that user would like more verbose output
         """
         self.session_id = session_id
         self.results_dir = os.path.abspath(results_dir)
         self.cluster = cluster
+        self.debug = debug
 
         self._logger_configured = False
-        self.configure_logger(log_config)
+        self.configure_logger()
 
     @property
     def logger_name(self):
         return self.session_id + ".session_logger"
 
-    def configure_logger(self, log_config=None):
+    def configure_logger(self):
         """
         :type session_context: ducktape.tests.session.SessionContext
 
@@ -64,7 +66,7 @@ class SessionContext(Logger):
 
         # create console handler with a higher log level
         ch = logging.StreamHandler(sys.stdout)
-        ch.setLevel(logging.INFO)
+        ch.setLevel(logging.DEBUG if self.debug else logging.INFO)
 
         # create formatter and add it to the handlers
         formatter = logging.Formatter(ConsoleConfig.SESSION_LOG_FORMATTER)
@@ -112,7 +114,6 @@ def generate_session_id(session_id_file):
             next_num = 1
 
         return get_id(next_day, next_num)
-
 
     if os.path.isfile(session_id_file):
         with open(session_id_file, "r") as fp:

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -116,7 +116,7 @@ class Test(object):
 
 class TestContext(Logger):
     """Wrapper class for state variables needed to properly run a single 'test unit'."""
-    def __init__(self, session_context, module, cls, function, config=None, log_config=None):
+    def __init__(self, session_context, module, cls, function, config=None):
         """
         :type session_context: ducktape.tests.session.SessionContext
         """
@@ -136,7 +136,7 @@ class TestContext(Logger):
         mkdir_p(self.results_dir)
 
         self._logger_configured = False
-        self.configure_logger(log_config)
+        self.configure_logger()
 
     @property
     def test_id(self):
@@ -154,7 +154,7 @@ class TestContext(Logger):
     def logger_name(self):
         return self.test_id
 
-    def configure_logger(self, log_config=None):
+    def configure_logger(self):
         if self._logger_configured:
             raise RuntimeError("test logger should only be configured once.")
 
@@ -163,9 +163,11 @@ class TestContext(Logger):
         mkdir_p(self.results_dir)
         fh = logging.FileHandler(os.path.join(self.results_dir, "test_log"))
         fh.setLevel(logging.DEBUG)
+
         # create console handler with a higher log level
         ch = logging.StreamHandler(sys.stdout)
-        ch.setLevel(logging.INFO)
+        ch.setLevel(logging.DEBUG if self.session_context.debug else logging.INFO)
+
         # create formatter and add it to the handlers
         formatter = logging.Formatter(ConsoleConfig.TEST_LOG_FORMATTER)
         fh.setFormatter(formatter)
@@ -173,7 +175,8 @@ class TestContext(Logger):
 
         # add the handlers to the logger
         self.logger.addHandler(fh)
-        # test_context.logger.addHandler(ch)
+        if self.session_context.debug:
+            self.logger.addHandler(ch)
 
         self._logger_configured = True
 

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -44,6 +44,9 @@ class Test(object):
         """
         return self.services.num_nodes()
 
+    def allocate_nodes(self):
+        self.services.allocate_nodes()
+
     def tearDown(self):
         """Default teardown method which stops and cleans services registered in the ServiceRegistry.
         Note that there is not a default setUp method. This is because the framework makes no assumptions
@@ -53,7 +56,9 @@ class Test(object):
             self.services.stop_all()
             self.copy_service_logs()
             self.services.clean_all()
-            self.services.free_all()
+
+    def free_nodes(self):
+        self.services.free_all()
 
     def copy_service_logs(self):
         """Copy logs from service nodes to the results directory."""

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -68,7 +68,7 @@ class Test(object):
                 # Gather locations of logs to collect
                 node_logs = []
                 for log_name in log_dirs.keys():
-                    if self.should_collect_log(log_name, service, node):
+                    if self.should_collect_log(log_name, service):
                         node_logs.append(log_dirs[log_name]["path"])
 
                 if len(node_logs) > 0:
@@ -91,24 +91,14 @@ class Test(object):
                              'service': service,
                              'message': e.message})
 
-    def mark_for_collect(self, service, log_name=None, node=None):
-        if node is None:
-            # By default, mark all nodes for collection
-            for n in service.nodes:
-                self.test_context.log_collect[(log_name, service, n.account.hostname)] = True
-        else:
-            self.test_context.log_collect[(log_name, service, node.account.hostname)] = True
+    def mark_for_collect(self, service, log_name=None):
+        self.test_context.log_collect[(log_name, service)] = True
 
-    def mark_no_collect(self, service, log_name=None, node=None):
-        if node is None:
-            # By default, mark all nodes for collection
-            for n in service.nodes:
-                self.test_context.log_collect[(log_name, service, n.account.hostname)] = False
-        else:
-            self.test_context.log_collect[(log_name, service, node.account.hostname)] = False
+    def mark_no_collect(self, service, log_name=None):
+        self.test_context.log_collect[(log_name, service)] = False
 
-    def should_collect_log(self, log_name, service, node):
-        key = (log_name, service, node.account.hostname)
+    def should_collect_log(self, log_name, service):
+        key = (log_name, service)
         default = service.logs[log_name]["collect_default"]
         val = self.test_context.log_collect.get(key, default)
         return val

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -45,11 +45,30 @@ class CheckTestLoader(object):
         test_classes = loader.discover([os.path.join(discover_dir(), "test_a.py")])
         assert len(test_classes) == 1
 
+    def check_test_loader_multiple_files(self):
+        loader = TestLoader(self.SESSION_CONTEXT)
+        test_classes = loader.discover([
+            os.path.join(discover_dir(), "test_a.py"),
+            os.path.join(discover_dir(), "test_b.py")
+
+        ])
+        assert len(test_classes) == 3
+
     def check_test_loader_with_nonexistent_file(self):
         """Check discovery on a starting path that doesn't exist throws an"""
         with pytest.raises(LoaderException):
             loader = TestLoader(self.SESSION_CONTEXT)
             test_classes = loader.discover([os.path.join(discover_dir(), "file_that_does_not_exist.py")])
+
+    def check_test_loader_with_class(self):
+        """Check test discovery with discover class syntax."""
+        loader = TestLoader(self.SESSION_CONTEXT)
+        test_classes = loader.discover([os.path.join(discover_dir(), "test_b.py::TestBB")])
+        assert len(test_classes) == 1
+
+        # Sanity check, test that it discovers two tests if it searches the whole module
+        test_classes = loader.discover([os.path.join(discover_dir(), "test_b.py")])
+        assert len(test_classes) == 2
 
 
 


### PR DESCRIPTION
Added mechanism to pull service logs from service nodes, but still need to add mechanism for toggling collection on/off.

Refactored Service to have a few more lifecycle methods:
allocate_nodes
start, start_node
wait_until_alive
stop, stop_node
clean, clean_node
free, free_node

This allows the test runner to have control over log collection, cleanup and cluster resource allocation even when Exceptions are thrown by the test.

Added ServiceRegistry class - Test classes must now 'register' services during construction. The test runner only allocates nodes to registered services.

Test gets a default tearDown method but no default setUp.
