### PR TITLE
Support multiple tests per Test class.

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -23,8 +23,8 @@ import traceback
 
 class TestRunner(object):
     """Abstract class responsible for running one or more tests."""
-    def __init__(self, session_context, test_classes):
-        self.tests = test_classes
+    def __init__(self, session_context, tests):
+        self.tests = tests
         self.session_context = session_context
         self.results = TestResults(self.session_context)
         self.cluster = session_context.cluster
@@ -40,7 +40,7 @@ class TestRunner(object):
         raise NotImplementedError()
 
 
-def create_test_case(test_class, session_context):
+def create_test_case(test, session_context):
     """Create test context object and instantiate test class.
 
     :type test_class: ducktape.tests.test.Test.__class__
@@ -48,8 +48,9 @@ def create_test_case(test_class, session_context):
     :rtype test_class
     """
 
-    test_context = TestContext(session_context, test_class.__module__, test_class, test_class.run, config=None)
-    return test_class(test_context)
+    test_class = test.im_class
+    test_context = TestContext(session_context, test_class.__module__, test_class, test, config=None)
+    return (test_context, test_class(test_context))
 
 
 class SerialTestRunner(TestRunner):
@@ -58,36 +59,42 @@ class SerialTestRunner(TestRunner):
     # When set to True, the test runner will finish running/cleaning the current test, but it will not run any more
     stop_testing = False
 
+    def __init__(self, *args, **kwargs):
+        super(SerialTestRunner, self).__init__(*args, **kwargs)
+        self.current_test = None
+        self.current_test_context = None
+
     def run_all_tests(self):
 
         self.results.start_time = time.time()
         for test in self.tests:
             # Create single testable unit and corresponding test result object
-            test_case = create_test_case(test, self.session_context)
-            result = TestResult(test_case.test_context, test_case.who_am_i())
+            self.current_test_context, self.current_test = create_test_case(test, self.session_context)
+            result = TestResult(self.current_test_context, self.current_test_context.test_name)
 
             # Run the test unit
             try:
-                self.log(logging.INFO, test_case, "setting up")
-                self.setup_single_test(test_case)
+                self.log(logging.INFO, "setting up")
+                self.setup_single_test()
 
-                self.log(logging.INFO, test_case, "running")
+                self.log(logging.INFO, "running")
                 result.start_time = time.time()
-                result.data = self.run_single_test(test_case)
-                self.log(logging.INFO, test_case, "PASS")
+                result.data = self.run_single_test()
+                self.log(logging.INFO, "PASS")
 
             except BaseException as e:
-                self.log(logging.INFO, test_case, "FAIL")
+                self.log(logging.INFO, "FAIL")
                 result.success = False
                 result.summary += e.message + "\n" + traceback.format_exc(limit=16)
 
                 self.stop_testing = self.session_context.exit_first or isinstance(e, KeyboardInterrupt)
 
             finally:
-                self.log(logging.INFO, test_case, "tearing down")
-                self.teardown_single_test(test_case)
+                self.log(logging.INFO, "tearing down")
+                self.teardown_single_test()
                 result.stop_time = time.time()
                 self.results.append(result)
+                self.current_test_context, self.current_test = None, None
 
             if self.stop_testing:
                 break
@@ -95,64 +102,63 @@ class SerialTestRunner(TestRunner):
         self.results.stop_time = time.time()
         return self.results
 
-    def setup_single_test(self, test):
+    def setup_single_test(self):
         """start services etc"""
 
-        self.log(logging.DEBUG, test, "Checking if there are enough nodes...")
-        if test.min_cluster_size() > self.cluster.num_available_nodes():
+        self.log(logging.DEBUG, "Checking if there are enough nodes...")
+        if self.current_test.min_cluster_size() > self.cluster.num_available_nodes():
             raise RuntimeError(
                 "There are not enough nodes available in the cluster to run this test. Needed: %d, Available: %d" %
-                (test.min_cluster_size(), self.cluster.num_available_nodes()))
+                (self.current_test.min_cluster_size(), self.cluster.num_available_nodes()))
 
-        test.setUp()
+        self.current_test.setUp()
 
-    def run_single_test(self, test):
+    def run_single_test(self):
         """Run the test!"""
-        return test.run()
+        return self.current_test_context.function(self.current_test)
 
-    def teardown_single_test(self, test):
+    def teardown_single_test(self):
         """teardown method which stops services, gathers log data, removes persistent state, and releases cluster nodes.
 
         Catch all exceptions so that every step in the teardown process is tried, but signal that the test runner
         should stop if a keyboard interrupt is caught.
         """
-        test_context = test.test_context
         exceptions = []
-        if hasattr(test_context, 'services'):
-            services = test_context.services
+        if hasattr(self.current_test_context, 'services'):
+            services = self.current_test_context.services
             try:
                 services.stop_all()
             except BaseException as e:
                 exceptions.append(e)
-                self.log(logging.WARN, test, "Error stopping services: %s" % e.message + "\n" + traceback.format_exc(limit=16))
+                self.log(logging.WARN, "Error stopping services: %s" % e.message + "\n" + traceback.format_exc(limit=16))
 
             try:
-                test.copy_service_logs()
+                self.current_test.copy_service_logs()
             except BaseException as e:
                 exceptions.append(e)
-                self.log(logging.WARN, test, "Error copying service logs: %s" % e.message + "\n" + traceback.format_exc(limit=16))
+                self.log(logging.WARN, "Error copying service logs: %s" % e.message + "\n" + traceback.format_exc(limit=16))
 
             try:
                 services.clean_all()
             except BaseException as e:
                 exceptions.append(e)
-                self.log(logging.WARN, test, "Error cleaning services: %s" % e.message + "\n" + traceback.format_exc(limit=16))
+                self.log(logging.WARN, "Error cleaning services: %s" % e.message + "\n" + traceback.format_exc(limit=16))
 
         try:
-            test.free_nodes()
+            self.current_test.free_nodes()
         except BaseException as e:
             exceptions.append(e)
-            self.log(logging.WARN, test, "Error freeing nodes: %s" % e.message + "\n" + traceback.format_exc(limit=16))
+            self.log(logging.WARN, "Error freeing nodes: %s" % e.message + "\n" + traceback.format_exc(limit=16))
 
         if len([e for e in exceptions if isinstance(e, KeyboardInterrupt)]) > 0:
             # Signal no more tests if we caught a keyboard interrupt
             self.stop_testing = True
 
-    def log(self, log_level, test, msg):
+    def log(self, log_level, msg):
         """Log to the service log and the test log of the given test."""
-        msg = "%s: %s: %s" % (self.who_am_i(), test.who_am_i(), msg)
+        msg = "%s: %s: %s" % (self.who_am_i(), self.current_test_context.test_name, msg)
         self.logger.log(log_level, msg)
-        test.logger.log(log_level, msg)
+        self.current_test.logger.log(log_level, msg)
 
 
 

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -35,10 +35,6 @@ class Test(TemplateRenderer):
         self.test_context = test_context
         self.logger = test_context.logger
 
-    def who_am_i(self):
-        """Human-readable name for help with logging."""
-        return self.__module__.split(".")[-1] + "." + self.__class__.__name__
-
     def min_cluster_size(self):
         """Heuristic for guessing whether there are enough nodes in the cluster to run this test.
 
@@ -131,6 +127,8 @@ class TestContext(Logger):
         self.results_dir = self.session_context.results_dir
         if self.cls is not None:
             self.results_dir = os.path.join(self.results_dir, self.cls.__name__)
+        if self.function is not None:
+            self.results_dir = os.path.join(self.results_dir, self.function.__name__)
         mkdir_p(self.results_dir)
 
         self._logger_configured = False
@@ -140,6 +138,18 @@ class TestContext(Logger):
     def test_id(self):
         name_components = [self.session_context.session_id,
                            self.module,
+                           self.cls.__name__ if self.cls is not None else None,
+                           self.function.__name__ if self.function is not None else None]
+
+        return ".".join(filter(lambda x: x is not None, name_components))
+
+    @property
+    def test_name(self):
+        """
+        The fully-qualified name of the test. This is similar to test_id, but does not include the session ID. It
+        includes the module, class, and method name.
+        """
+        name_components = [self.module,
                            self.cls.__name__ if self.cls is not None else None,
                            self.function.__name__ if self.function is not None else None]
 

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -38,39 +38,38 @@ class CheckTestLoader(object):
     def check_test_loader_with_directory(self):
         """Check discovery on a directory."""
         loader = TestLoader(self.SESSION_CONTEXT)
-        test_classes = loader.discover([discover_dir()])
-        assert len(test_classes) == 4
+        tests = loader.discover([discover_dir()])
+        assert len(tests) == 5
 
     def check_test_loader_with_file(self):
         """Check discovery on a file. """
         loader = TestLoader(self.SESSION_CONTEXT)
-        test_classes = loader.discover([os.path.join(discover_dir(), "test_a.py")])
-        assert len(test_classes) == 1
+        tests = loader.discover([os.path.join(discover_dir(), "test_a.py")])
+        assert len(tests) == 1
 
     def check_test_loader_multiple_files(self):
         loader = TestLoader(self.SESSION_CONTEXT)
-        test_classes = loader.discover([
+        tests = loader.discover([
             os.path.join(discover_dir(), "test_a.py"),
             os.path.join(discover_dir(), "test_b.py")
-
         ])
-        assert len(test_classes) == 3
+        assert len(tests) == 4
 
     def check_test_loader_with_nonexistent_file(self):
         """Check discovery on a starting path that doesn't exist throws an"""
         with pytest.raises(LoaderException):
             loader = TestLoader(self.SESSION_CONTEXT)
-            test_classes = loader.discover([os.path.join(discover_dir(), "file_that_does_not_exist.py")])
+            tests = loader.discover([os.path.join(discover_dir(), "file_that_does_not_exist.py")])
 
     def check_test_loader_with_class(self):
         """Check test discovery with discover class syntax."""
         loader = TestLoader(self.SESSION_CONTEXT)
-        test_classes = loader.discover([os.path.join(discover_dir(), "test_b.py::TestBB")])
-        assert len(test_classes) == 1
+        tests = loader.discover([os.path.join(discover_dir(), "test_b.py::TestBB")])
+        assert len(tests) == 2
 
-        # Sanity check, test that it discovers two tests if it searches the whole module
-        test_classes = loader.discover([os.path.join(discover_dir(), "test_b.py")])
-        assert len(test_classes) == 2
+        # Sanity check, test that it discovers two test class & 3 tests if it searches the whole module
+        tests = loader.discover([os.path.join(discover_dir(), "test_b.py")])
+        assert len(tests) == 3
 
 
 

--- a/tests/loader/resources/loader_test_directory/sub_dir_a/test_c.py
+++ b/tests/loader/resources/loader_test_directory/sub_dir_a/test_c.py
@@ -17,9 +17,10 @@ from ducktape.tests.test import Test
 
 class TestC(Test):
     """Loader should discover this."""
-    pass
-
+    def test_c(self):
+        pass
 
 class TestInvisible(object):
     """Loader should not discover this."""
-    pass
+    def test_invisible(self):
+        pass

--- a/tests/loader/resources/loader_test_directory/test_a.py
+++ b/tests/loader/resources/loader_test_directory/test_a.py
@@ -17,9 +17,10 @@ from ducktape.tests.test import Test
 
 class TestA(Test):
     """Loader should discover this."""
-    pass
-
+    def test_a(self):
+        pass
 
 class TestInvisible(object):
     """Loader should not discover this."""
-    pass
+    def test_invisible(self):
+        pass

--- a/tests/loader/resources/loader_test_directory/test_b.py
+++ b/tests/loader/resources/loader_test_directory/test_b.py
@@ -17,14 +17,23 @@ from ducktape.tests.test import Test
 
 class TestB(Test):
     """Loader should discover this."""
-    pass
-
+    def test_b(self):
+        pass
 
 class TestBB(Test):
-    """Loader should discover this."""
-    pass
+    """Loader should discover this with 2 tests."""
+    test_not_callable = 3
 
+    def test_bb_one(self):
+        pass
+
+    def bb_two_test(self):
+        pass
+
+    def other_method(self):
+        pass
 
 class TestInvisible(object):
     """Loader should not discover this."""
-    pass
+    def test_invisible(self):
+        pass


### PR DESCRIPTION
Test methods must be name test.* or .*test. The test loader now supports
matching up to the test method in the format
file.py::TestClass.test_method. Test contexts are now preferred when logging
some information since only having the test class name is no longer
sufficient. Fixes #49.