### PR TITLE
Add option to control cluster type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Use the `--collect-only` flag to discover tests without running any:
 
     ducktape <path_to_testfile_or_directory> --collect-only
 
+Configuration
+-------------
+
+To see a complete listing of options run:
+
+    ducktape --help
+
+You can configure options in three locations: on the command line (highest priority), in a user configuration file in
+`~/.ducktape/config`, and in a project-specific configuration `<project_dir>/.ducktape/config` (lowest priority).
+Configuration files use the same syntax as command line arguments and may split arguments across multiple lines, e.g.:
+
+    --debug
+    --exit-first
+    --cluster=ducktape.cluster.json.JsonCluster
+
 Test Output
 -----------
 Test results go in `results/<session_id>`. `<session_id>` looks like `<date>--<test_number>`. For example, `results/2015-03-28--002`

--- a/ducktape/command_line/config.py
+++ b/ducktape/command_line/config.py
@@ -16,11 +16,14 @@ import os
 
 
 class ConsoleConfig(object):
+    # Directory for project-specific ducktape configs and runtime data
+    DUCKTAPE_DIR = ".ducktape"
+
     # Store various bookkeeping data here
-    METADATA_DIR = ".ducktape"
+    METADATA_DIR = os.path.join(DUCKTAPE_DIR, "metadata")
 
     # Default path, relative to current project directory, to the project's ducktape config file
-    PROJECT_CONFIG_FILE = os.path.join(METADATA_DIR, "config")
+    PROJECT_CONFIG_FILE = os.path.join(DUCKTAPE_DIR, "config")
 
     # Default path to the user-specific config file
     USER_CONFIG_FILE = '~/.ducktape/config'

--- a/ducktape/command_line/config.py
+++ b/ducktape/command_line/config.py
@@ -26,7 +26,7 @@ class ConsoleConfig(object):
     PROJECT_CONFIG_FILE = os.path.join(DUCKTAPE_DIR, "config")
 
     # Default path to the user-specific config file
-    USER_CONFIG_FILE = '~/.ducktape/config'
+    USER_CONFIG_FILE = os.path.join('~', DUCKTAPE_DIR, 'config')
 
     # Default cluster implementation
     CLUSTER_TYPE = "ducktape.cluster.vagrant.VagrantCluster"

--- a/ducktape/command_line/config.py
+++ b/ducktape/command_line/config.py
@@ -19,6 +19,15 @@ class ConsoleConfig(object):
     # Store various bookkeeping data here
     METADATA_DIR = ".ducktape"
 
+    # Default path, relative to current project directory, to the project's ducktape config file
+    PROJECT_CONFIG_FILE = os.path.join(METADATA_DIR, "config")
+
+    # Default path to the user-specific config file
+    USER_CONFIG_FILE = '~/.ducktape/config'
+
+    # Default cluster implementation
+    CLUSTER_TYPE = "ducktape.cluster.vagrant.VagrantCluster"
+
     # Track the last-used session_id here
     SESSION_ID_FILE = os.path.join(METADATA_DIR, "session_id")
 

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -113,6 +113,8 @@ def main():
 
     setup_results_directory(results_dir, session_id)
     session_context = SessionContext(session_id, results_dir, cluster=None, args=args)
+    for k,v in vars(args).iteritems():
+        session_context.logger.debug("Configuration: %s=%s", k, v)
 
     # Discover and load tests to be run
     extend_import_paths(args.test_path)

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -39,8 +39,10 @@ def parse_args():
                         help='one or more space-delimited strings indicating where to search for tests')
     parser.add_argument("--collect-only", action="store_true", help="display collected tests, but do not run")
     parser.add_argument("--debug", action="store_true", help="pipe more verbose test output to stdout")
-    parser.add_argument("--cluster", action="store", default="ducktape.cluster.vagrant.VagrantCluster",
-                        help="Cluster class to use to allocate nodes for tests")
+    parser.add_argument("--config-file", action="store", default=ConsoleConfig.PROJECT_CONFIG_FILE,
+                        help="path to project-specific configuration file")
+    parser.add_argument("--cluster", action="store", default=ConsoleConfig.CLUSTER_TYPE,
+                        help="cluster class to use to allocate nodes for tests")
     parser.add_argument("--exit-first", action="store_true", help="exit after first failure")
 
     project_configs = []
@@ -49,7 +51,7 @@ def parse_args():
         project_configs = list(itertools.chain(*[line.split() for line in open(project_config_file).readlines()]))
 
     user_configs = []
-    user_config_file = os.path.expanduser('~/.ducktape/config')
+    user_config_file = os.path.expanduser(ConsoleConfig.USER_CONFIG_FILE)
     if os.path.exists(user_config_file):
         user_configs = list(itertools.chain(*[line.split() for line in open(user_config_file).readlines()]))
 

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -30,7 +30,7 @@ def parse_args():
     """Parse in command-line and config file options.
 
     Command line arguments have the highest priority, then user configs specified in ~/.ducktape/config, and finally
-    project configs specified in <ducktape_metadata_dir>/config.
+    project configs specified in <ducktape_dir>/config.
 
     :rtype: argparse.Namespace
     """
@@ -46,7 +46,7 @@ def parse_args():
     parser.add_argument("--exit-first", action="store_true", help="exit after first failure")
 
     project_configs = []
-    project_config_file = os.path.join(ConsoleConfig.METADATA_DIR, 'config')
+    project_config_file = ConsoleConfig.PROJECT_CONFIG_FILE
     if os.path.exists(project_config_file):
         project_configs = list(itertools.chain(*[line.split() for line in open(project_config_file).readlines()]))
 

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -16,7 +16,6 @@ from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.runner import SerialTestRunner
 from ducktape.tests.reporter import SimpleStdoutReporter, SimpleFileReporter, HTMLReporter
 from ducktape.tests.session import SessionContext
-from ducktape.cluster.vagrant import VagrantCluster
 from ducktape.command_line.config import ConsoleConfig
 from ducktape.tests.session import generate_session_id, generate_results_dir
 from ducktape.utils.local_filesystem_utils import mkdir_p
@@ -24,10 +23,15 @@ from ducktape.utils.local_filesystem_utils import mkdir_p
 import argparse
 import os
 import sys
-
+import importlib
+import itertools
 
 def parse_args():
-    """Parse in command-line options.
+    """Parse in command-line and config file options.
+
+    Command line arguments have the highest priority, then user configs specified in ~/.ducktape/config, and finally
+    project configs specified in <ducktape_metadata_dir>/config.
+
     :rtype: argparse.Namespace
     """
     parser = argparse.ArgumentParser(description="Discover and run your tests")
@@ -35,9 +39,23 @@ def parse_args():
                         help='one or more space-delimited strings indicating where to search for tests')
     parser.add_argument("--collect-only", action="store_true", help="display collected tests, but do not run")
     parser.add_argument("--debug", action="store_true", help="pipe more verbose test output to stdout")
+    parser.add_argument("--cluster", action="store", default="ducktape.cluster.vagrant.VagrantCluster",
+                        help="Cluster class to use to allocate nodes for tests")
     parser.add_argument("--exit-first", action="store_true", help="exit after first failure")
 
-    args = parser.parse_args()
+    project_configs = []
+    project_config_file = os.path.join(ConsoleConfig.METADATA_DIR, 'config')
+    if os.path.exists(project_config_file):
+        project_configs = list(itertools.chain(*[line.split() for line in open(project_config_file).readlines()]))
+
+    user_configs = []
+    user_config_file = os.path.expanduser('~/.ducktape/config')
+    if os.path.exists(user_config_file):
+        user_configs = list(itertools.chain(*[line.split() for line in open(user_config_file).readlines()]))
+
+    # The order of concatenation ensures overrides are handled properly -- for action=store arguments, the later options
+    # will override earlier instances
+    args = parser.parse_args(project_configs + user_configs + sys.argv[1:])
     return args
 
 
@@ -80,11 +98,11 @@ def main():
         Run tests
         Report a summary of all results
     """
-    args = parse_args()
-
     # Make .ducktape directory where metadata such as the last used session_id is stored
     if not os.path.isdir(ConsoleConfig.METADATA_DIR):
         os.makedirs(ConsoleConfig.METADATA_DIR)
+
+    args = parse_args()
 
     # Generate a shared 'global' identifier for this test run and create the directory
     # in which all test results will be stored
@@ -109,7 +127,14 @@ def main():
 
     # Initializing the cluster is slow, so do so only if
     # tests are sure to be run
-    session_context.cluster = VagrantCluster()
+    try:
+        (cluster_mod_name, cluster_class_name) = args.cluster.rsplit('.', 1)
+        cluster_mod = importlib.import_module(cluster_mod_name)
+        cluster_class = getattr(cluster_mod, cluster_class_name)
+        session_context.cluster = cluster_class()
+    except:
+        print "Failed to load cluster: ", str(sys.exc_info()[0])
+        sys.exit(1)
 
     # Run the tests
     runner = SerialTestRunner(session_context, test_classes)


### PR DESCRIPTION
To allow setting it on a per-project or per-user basis, this also adds support
for loading configs from config files in addition to the command line. Fixes #33.