### PR TITLE
Mark start of test before setup so we report the entire duration of the test. Fixes #63.

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -78,13 +78,13 @@ class SerialTestRunner(TestRunner):
             result = TestResult(self.current_test_context, self.current_test_context.test_name)
 
             # Run the test unit
+            result.start_time = time.time()
             self.log(logging.INFO, "running test %d of %d" % (test_num, len(self.tests)))
             try:
                 self.log(logging.INFO, "setting up")
                 self.setup_single_test()
 
                 self.log(logging.INFO, "running")
-                result.start_time = time.time()
                 result.data = self.run_single_test()
                 self.log(logging.INFO, "PASS")
 


### PR DESCRIPTION
This just moves up the line that lists the start time.

I noticed that the current logging doesn't make it clear when the test ends either since nothing is logged immediately when the test ends, so the last checkpoint you have is when teardown started, but there can be quite a bit of work to do after that. I think this is fine though since a) the reported time is now accurate for the complete test and b) you can get close enough using the next test's start time.