### PR TITLE
Issue 62 min cluster

### DIFF
--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -22,9 +22,6 @@ class ClusterSlot(object):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    def __repr__(self):
-        return "<ClusterSlot: account: " + str(self.account) + ">"
-
     def free(self):
         self.parent.free(self)
 
@@ -38,9 +35,7 @@ class Cluster(object):
     """
 
     def __len__(self):
-        """Size of this cluster object. I.e. number of 'nodes' in the cluster.
-        In some implementations this may be float('infinity').
-        """
+        """Size of this cluster object. I.e. number of 'nodes' in the cluster."""
         raise NotImplementedError()
 
     def request(self, nslots):

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -34,6 +34,12 @@ class Cluster(object):
     homogeneous.
     """
 
+    def __len__(self):
+        """Size of this cluster object. I.e. number of 'nodes' in the cluster.
+        In some implementations this may be float('infinity').
+        """
+        raise NotImplementedError()
+
     def request(self, nslots):
         """Request the specified number of slots, which will be reserved until they are freed by the caller."""
         raise NotImplementedError()

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -19,8 +19,11 @@ class ClusterSlot(object):
     def __init__(self, parent, account, **kwargs):
         self.parent = parent
         self.account = account
-        for k,v in kwargs.items():
+        for k, v in kwargs.items():
             setattr(self, k, v)
+
+    def __repr__(self):
+        return "<ClusterSlot: account: " + str(self.account) + ">"
 
     def free(self):
         self.parent.free(self)

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -38,14 +38,19 @@ class JsonCluster(Cluster):
         self.in_use_nodes = set()
         self.id_source = 1
 
+    def __len__(self):
+        return len(self.available_nodes) + len(self.in_use_nodes)
+
     def num_available_nodes(self):
         return len(self.available_nodes)
 
     def request(self, nslots):
         if nslots > self.num_available_nodes():
-            raise RuntimeError(
-                "There aren't enough available nodes to satisfy the resource request. Your test has almost " +
-                "certainly incorrectly implemented its min_cluster_size() method.")
+            err_msg = "There aren't enough available nodes to satisfy the resource request. " \
+                "Cluster size: %d, Requested: %d, Available: %d. " % \
+                      (len(self), nslots, self.num_available_nodes())
+            err_msg += "Make sure your cluster has enough nodes to run your test or service(s)."
+            raise RuntimeError(err_msg)
 
         result = []
         for i in range(nslots):

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -47,8 +47,8 @@ class JsonCluster(Cluster):
     def request(self, nslots):
         if nslots > self.num_available_nodes():
             err_msg = "There aren't enough available nodes to satisfy the resource request. " \
-                "Cluster size: %d, Requested: %d, Available: %d. " % \
-                      (len(self), nslots, self.num_available_nodes())
+                "Total cluster size: %d, Requested: %d, Already allocated: %d, Available: %d. " % \
+                      (len(self), nslots, len(self.in_use_nodes), self.num_available_nodes())
             err_msg += "Make sure your cluster has enough nodes to run your test or service(s)."
             raise RuntimeError(err_msg)
 

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -29,7 +29,7 @@ class LocalhostCluster(Cluster):
         self._available = sys.maxint
 
     def __len__(self):
-        return float("infinity")
+        return sys.maxint
 
     def request(self, nslots):
         self._available -= nslots

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -28,6 +28,9 @@ class LocalhostCluster(Cluster):
         # Use a very large number, but fixed value so accounting for # of available nodes works
         self._available = sys.maxint
 
+    def __len__(self):
+        return float("infinity")
+
     def request(self, nslots):
         self._available -= nslots
         return [ClusterSlot(self, RemoteAccount("localhost")) for i in range(nslots)]

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -30,13 +30,12 @@ class RemoteAccount(HttpMixin):
         self.externally_routable_ip = None
         self.logger = logger
 
-    def __repr__(self):
-        r = ["hostname: %s" % self.hostname,
-             "user: %s" % ("" if self.user is None else self.user),
-             "ssh_hostname: %s" % ("" if self.ssh_hostname is None else self.ssh_hostname),
-             "ssh_args: %s" % ("" if self.ssh_args is None else self.ssh_args)]
-
-        return "<RemoteAccount: " + ", ".join(r) + ">"
+    def __str__(self):
+        r = ""
+        if self.user:
+            r += self.user + "@"
+        r += self.hostname
+        return r
 
     @property
     def local(self):
@@ -194,10 +193,4 @@ class RemoteAccount(HttpMixin):
                 return
             raise e
 
-    def __str__(self):
-        r = ""
-        if self.user:
-            r += self.user + "@"
-        r += self.hostname
-        return r
 

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -28,11 +28,15 @@ class RemoteAccount(HttpMixin):
         self.ssh_args = ssh_args
         self.ssh_hostname = ssh_hostname
         self.externally_routable_ip = None
-
         self.logger = logger
 
-    def set_logger(self, logger):
-        self.logger = logger
+    def __repr__(self):
+        r = ["hostname: %s" % self.hostname,
+             "" if self.user is None else self.user,
+             "" if self.ssh_args is None else self.ssh_args,
+             "" if self.ssh_hostname is None else self.ssh_hostname]
+
+        return "<RemoteAccount: " + ", ".join(r) + ">"
 
     @property
     def local(self):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -32,9 +32,9 @@ class RemoteAccount(HttpMixin):
 
     def __repr__(self):
         r = ["hostname: %s" % self.hostname,
-             "" if self.user is None else self.user,
-             "" if self.ssh_args is None else self.ssh_args,
-             "" if self.ssh_hostname is None else self.ssh_hostname]
+             "user: %s" % ("" if self.user is None else self.user),
+             "ssh_hostname: %s" % ("" if self.ssh_hostname is None else self.ssh_hostname),
+             "ssh_args: %s" % ("" if self.ssh_args is None else self.ssh_args)]
 
         return "<RemoteAccount: " + ", ".join(r) + ">"
 

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -123,7 +123,7 @@ def main():
 
     setup_results_directory(results_dir, session_id)
     session_context = SessionContext(session_id, results_dir, cluster=None, args=args)
-    for k,v in vars(args).iteritems():
+    for k, v in vars(args).iteritems():
         session_context.logger.debug("Configuration: %s=%s", k, v)
 
     # Discover and load tests to be run

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -94,7 +94,6 @@ class Service(TemplateRenderer):
         except RuntimeError as e:
             if hasattr(self.context, "services"):
                 msg = e.message + " Currently registered services: " + str(self.context.services)
-                self.logger.debug("Currently registered services: " + str(self.context.services))
             raise RuntimeError(msg)
 
         for idx, node in enumerate(self.nodes, 1):

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -64,9 +64,8 @@ class Service(TemplateRenderer):
             self.context.services.append(self)
 
     def __repr__(self):
-        d = "num_nodes: %d, allocated: %s, nodes: %s" % (self.num_nodes, self.allocated, self.nodes)
-
-        return "<%s: %s>" % (self.who_am_i(), str(d))
+        return "<%s: %s>" % (self.who_am_i(), "num_nodes: %d, allocated: %s, nodes: %s" %
+                             (self.num_nodes, self.allocated, [n.account.hostname for n in self.nodes]))
 
     @property
     def logger(self):

--- a/ducktape/tests/loader.py
+++ b/ducktape/tests/loader.py
@@ -55,9 +55,12 @@ class TestLoader(object):
 
     def __init__(self, session_context):
         self.session_context = session_context
-        self.logger = session_context.logger
         self.test_file_pattern = DEFAULT_TEST_FILE_PATTERN
         self.test_function_pattern = DEFAULT_TEST_FUNCTION_PATTERN
+
+    @property
+    def logger(self):
+        return self.session_context.logger
 
     def parse_discovery_symbol(self, discovery_symbol):
         """Parse command-line argument into a tuple (directory, module.py, cls_name, function_name).

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -32,9 +32,15 @@ class Test(TemplateRenderer):
         :type test_context: ducktape.tests.test.TestContext
         """
         super(Test, self).__init__(*args, **kwargs)
-        self.cluster = test_context.session_context.cluster
         self.test_context = test_context
-        self.logger = test_context.logger
+
+    @property
+    def cluster(self):
+        return self.test_context.session_context.cluster
+
+    @property
+    def logger(self):
+        return self.test_context.logger
 
     def min_cluster_size(self):
         """Heuristic for guessing whether there are enough nodes in the cluster to run this test.

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name="ducktape",
       packages=find_packages(),
       package_data={'ducktape': ['templates/report/*']},
       install_requires=['jinja2', 'requests'],
-      tests_require=['pytest', 'jinja2', 'requests'],
+      tests_require=['pytest'],
       cmdclass={'test': PyTest},
       )

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ class PyTest(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
+requires = ['jinja2', 'requests']
+
 setup(name="ducktape",
       version=version,
       description="Distributed system test tools",
@@ -42,6 +44,7 @@ setup(name="ducktape",
       url="http://github.com/confluentinc/ducktape",
       packages=find_packages(),
       package_data={'ducktape': ['templates/report/*']},
-      tests_require=['pytest'],
+      install_requires=['jinja2', 'requests'],
+      tests_require=['pytest', 'jinja2', 'requests'],
       cmdclass={'test': PyTest},
       )

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ class PyTest(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
-requires = ['jinja2', 'requests']
-
 setup(name="ducktape",
       version=version,
       description="Distributed system test tools",

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name="ducktape",
       packages=find_packages(),
       package_data={'ducktape': ['templates/report/*']},
       install_requires=['jinja2', 'requests'],
-      tests_require=['pytest'],
+      tests_require=['pytest', 'mock'],
       cmdclass={'test': PyTest},
       )

--- a/tests/cluster/check_json.py
+++ b/tests/cluster/check_json.py
@@ -31,16 +31,27 @@ class CheckJsonCluster(object):
     def cluster_hostnames(nodes):
         return set([node.account.hostname for node in nodes])
 
+    def check_cluster_size(self):
+        cluster = JsonCluster({"nodes": []})
+        assert len(cluster) == 0
+
+        n = 10
+        cluster = JsonCluster({"nodes":[{"hostname": "localhost%d" % x} for x in range(n)]})
+        assert len(cluster) == n
+
     def check_allocate_free(self):
         cluster = JsonCluster({"nodes":[{"hostname": "localhost1"}, {"hostname": "localhost2"}, {"hostname": "localhost3"}]})
+        assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 3)
 
         nodes = cluster.request(1)
         nodes_hostnames = self.cluster_hostnames(nodes)
+        assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 2)
 
         nodes2 = cluster.request(2)
         nodes2_hostnames = self.cluster_hostnames(nodes2)
+        assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 0)
 
         assert(nodes_hostnames.isdisjoint(nodes2_hostnames))

--- a/tests/cluster/check_localhost.py
+++ b/tests/cluster/check_localhost.py
@@ -14,12 +14,18 @@
 
 from ducktape.cluster.localhost import LocalhostCluster
 
+import sys
+
 class CheckLocalhostCluster(object):
     def setup_method(self, method):
         self.cluster = LocalhostCluster()
 
+    def check_size(self):
+        len(self.cluster) >= 2 ** 31 - 1
+
     def check_request_free(self):
         available = self.cluster.num_available_nodes()
+        initial_size = len(self.cluster)
 
         # Should be able to allocate arbitrarily many nodes
         slots = self.cluster.request(100)
@@ -30,6 +36,7 @@ class CheckLocalhostCluster(object):
             assert(slot.account.ssh_args == None)
 
         assert(self.cluster.num_available_nodes() == (available - 100))
+        assert len(self.cluster) == initial_size  # This shouldn't change
 
         self.cluster.free(slots)
 

--- a/tests/cluster/check_vagrant.py
+++ b/tests/cluster/check_vagrant.py
@@ -47,6 +47,7 @@ Host worker2
 
 
         cluster = VagrantCluster()
+        assert len(cluster) == 2
         assert(cluster.num_available_nodes() == 2)
         node1, node2 = cluster.request(2)
 

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ducktape.tests.session import SessionContext
+
+import os
+import tempfile
+
 
 class MockArgs(object):
     """A mock command-line argument object"""
@@ -22,3 +27,12 @@ class MockArgs(object):
         self.debug = False
         self.exit_first = False
         self.no_teardown = False
+
+
+def session_context(cluster=None, args=MockArgs()):
+    """Return a SessionContext object."""
+
+    tmp = tempfile.mkdtemp()
+    session_dir = os.path.join(tmp, "test_dir")
+    os.mkdir(session_dir)
+    return SessionContext("test_session", session_dir, cluster=cluster, args=args)

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 from ducktape.tests.loader import TestLoader, LoaderException
-from ducktape.tests.session import SessionContext
 
-from tests.mock import MockArgs
+import tests.ducktape_mock
 
 import os
 import os.path
-import tempfile
 import pytest
 import re
 
@@ -58,10 +56,7 @@ def num_tests_in_dir(dpath):
 
 class CheckTestLoader(object):
     def setup_method(self, method):
-        tmp = tempfile.mkdtemp()
-        session_dir = os.path.join(tmp, "test_dir")
-        os.mkdir(session_dir)
-        self.SESSION_CONTEXT = SessionContext("test_session", session_dir, None, MockArgs())
+        self.SESSION_CONTEXT = tests.ducktape_mock.session_context()
 
     def check_test_loader_with_directory(self):
         """Check discovery on a directory."""

--- a/tests/runner/check_serial_runner.py
+++ b/tests/runner/check_serial_runner.py
@@ -1,0 +1,56 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.tests.test import TestContext, Test
+from ducktape.tests.runner import SerialTestRunner
+
+import tests.ducktape_mock
+
+from mock import MagicMock, Mock
+
+import pytest
+
+
+class CheckSerialRunner(object):
+
+    def check_insufficient_cluster_resources(self):
+        """The test runner should behave sensibly when the cluster is too small to run a given test."""
+        mock_cluster = MagicMock()
+        mock_cluster.__len__.return_value = 1
+        session_context = tests.ducktape_mock.session_context(mock_cluster)
+
+        test_context = TestContext(session_context, module=None, cls=TestThingy, function=TestThingy.test_pi)
+        runner = SerialTestRunner(session_context, [test_context])
+        runner.log = Mock()
+
+        # Even though the cluster is too small, the test runner should this handle gracefully without raising an error
+        runner.run_all_tests()
+
+        # Check that setup of TestThingy raises error
+        runner.current_test = TestThingy(test_context)
+        runner.current_test_context = test_context
+        with pytest.raises(RuntimeError):
+            # The cluster should be too small to setup the test
+            runner.setup_single_test()
+
+
+class TestThingy(Test):
+    """Fake ducktape test class"""
+
+    def min_cluster_size(self):
+        """ This test uses many nodes, wow!"""
+        return 1000
+
+    def test_pi(self):
+        return {"data": 3.14159}

--- a/tests/templates/test/check_render.py
+++ b/tests/templates/test/check_render.py
@@ -15,7 +15,7 @@
 from ducktape.tests.test import Test, TestContext
 from ducktape.tests.session import SessionContext
 
-from tests.mock import MockArgs
+from tests.ducktape_mock import MockArgs
 
 import tempfile
 


### PR DESCRIPTION
@gwenshap @ewencp 
Addresses #62 

Tried to clarify error messages when the cluster is too small or doesn't have enough free nodes by outputing info on: cluster size, number of nodes requested, number of available nodes. Output also includes info on how many nodes have been allocated to each different service so far.

The message about min_cluster_size is misleading - it's actually ok for min_cluster_size to underestimate. min_cluster_size is at best a lower bound because new services can be 'registered' at any time in a test.

I don't have any Vagrant - specific output in the error messages since we may not be using a Vagrant cluster, and there's way for us to know where the cluster size is actually being configured in general.