### PR TITLE
Configurable results dir

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -46,6 +46,10 @@ def parse_args():
                         help="path to project-specific configuration file")
     parser.add_argument("--cluster", action="store", default=ConsoleConfig.CLUSTER_TYPE,
                         help="cluster class to use to allocate nodes for tests")
+    parser.add_argument("--results-root", action="store", default=ConsoleConfig.RESULTS_ROOT_DIRECTORY,
+                        help="path to custom root results directory. Running ducktape with this root " +
+                             "specified will result in new test results being stored in a subdirectory of " +
+                             "this root directory.")
     parser.add_argument("--exit-first", action="store_true", help="exit after first failure")
     parser.add_argument("--no-teardown", action="store_true",
                         help="don't kill running processes or remove log files when a test has finished running. " +
@@ -123,7 +127,7 @@ def main():
     session_id = generate_session_id(ConsoleConfig.SESSION_ID_FILE)
     results_dir = generate_results_dir(session_id)
 
-    setup_results_directory(ConsoleConfig.RESULTS_ROOT_DIRECTORY, results_dir)
+    setup_results_directory(args.results_root, results_dir)
     session_context = SessionContext(session_id, results_dir, cluster=None, args=args)
     for k, v in vars(args).iteritems():
         session_context.logger.debug("Configuration: %s=%s", k, v)

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -125,7 +125,7 @@ def main():
     # Generate a shared 'global' identifier for this test run and create the directory
     # in which all test results will be stored
     session_id = generate_session_id(ConsoleConfig.SESSION_ID_FILE)
-    results_dir = generate_results_dir(session_id)
+    results_dir = generate_results_dir(args.results_root, session_id)
 
     setup_results_directory(args.results_root, results_dir)
     session_context = SessionContext(session_id, results_dir, cluster=None, args=args)

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -113,14 +113,14 @@ def main():
         Run tests
         Report a summary of all results
     """
-    # Make .ducktape directory where metadata such as the last used session_id is stored
-    if not os.path.isdir(ConsoleConfig.METADATA_DIR):
-        os.makedirs(ConsoleConfig.METADATA_DIR)
-
     args = parse_args()
     if args.version:
         print ducktape_version()
         sys.exit(0)
+
+    # Make .ducktape directory where metadata such as the last used session_id is stored
+    if not os.path.isdir(ConsoleConfig.METADATA_DIR):
+        os.makedirs(ConsoleConfig.METADATA_DIR)
 
     # Generate a shared 'global' identifier for this test run and create the directory
     # in which all test results will be stored

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -129,12 +129,12 @@ def generate_session_id(session_id_file):
     return session_id
 
 
-def generate_results_dir(session_id):
+def generate_results_dir(results_root, session_id):
     """Results from a single run of ducktape are assigned a session_id and put together in this directory.
 
     :type session_id: str
     :rtype: str
     """
-    return os.path.join(os.path.abspath(ConsoleConfig.RESULTS_ROOT_DIRECTORY), session_id)
+    return os.path.join(os.path.abspath(results_root), session_id)
 
 

--- a/tests/tests/check_session.py
+++ b/tests/tests/check_session.py
@@ -1,0 +1,27 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.tests.session import generate_results_dir
+
+import os.path
+import tempfile
+
+
+class CheckGenerateResultsDir(object):
+    def check_generate_results_root(self):
+        """Check the generated results directory has the specified path as its root"""
+        results_root = os.path.abspath(tempfile.mkdtemp())
+        results_dir = generate_results_dir(results_root, "my_session_id")
+        assert results_dir.find(results_root) == 0
+


### PR DESCRIPTION
@ewencp 

- added command-line option for configuring a custom directory for results. Addresses #37
- previously calling `ducktape --version` had the side effect of creating a metadata pwd/.ducktape. Removed this side-effect
