### PR TITLE
Make ssh utilities return exit status when failure is allowed so the caller can check whether the command was successful.

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -180,17 +180,21 @@ class RemoteAccount(HttpMixin):
     def _ssh_quiet(self, cmd, allow_fail=False):
         """Runs the command on the remote host using SSH and blocks until the remote command finishes.
 
-        If it succeeds, there is no output; if it fails the output is printed and the CalledProcessError is re-raised.
+        If it succeeds, there is no output; if it fails the output is printed
+        and the CalledProcessError is re-raised. If allow_fail is True, the
+        CalledProcess error will not be re-raised and the exit status of the
+        process will be returned instead.
         """
         try:
             self.logger.debug("Trying to run remote command: " + cmd)
             subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
+            return 0
         except subprocess.CalledProcessError as e:
             self.logger.warn("Error running remote command: " + cmd)
             self.logger.warn(e.output)
 
             if allow_fail:
-                return
+                return e.returncode
             raise e
 
 

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -70,6 +70,12 @@ class RemoteAccount(HttpMixin):
         return r
 
     def ssh(self, cmd, allow_fail=False):
+        """
+        Run the specified command on the remote host. If allow_fail is False and
+        the command returns a non-zero exit status, throws
+        subprocess.CalledProcessError. If allow_fail is True, returns the exit
+        status of the command.
+        """
         return self._ssh_quiet(self.ssh_command(cmd), allow_fail)
 
     def ssh_capture(self, cmd, allow_fail=False, callback=None):


### PR DESCRIPTION
@granders Quick and easy review. No tests because we don't have a good way to unit test anything involving ssh currently....