### PR TITLE
Update wait until

### DIFF
--- a/ducktape/utils/util.py
+++ b/ducktape/utils/util.py
@@ -17,20 +17,21 @@ from ducktape import __version__ as __ducktape_version__
 import time
 
 
-def wait_until(condition, timeout_sec, backoff_sec=.1):
+def wait_until(condition, timeout_sec, backoff_sec=.1, err_msg=""):
     """Block until condition evaluates as true or timeout expires, whichever comes first.
 
-    return True if condition becomes true within the timeout window, otherwise False
+    return silently if condition becomes true within the timeout window, otherwise raise Exception with the given
+    error message.
     """
     start = time.time()
     stop = start + timeout_sec
     while time.time() < stop:
         if condition():
-            return True
+            return
         else:
             time.sleep(backoff_sec)
 
-    return False
+    raise Exception(err_msg)
 
 
 def ducktape_version():

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/utils/check_util.py
+++ b/tests/utils/check_util.py
@@ -1,0 +1,36 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ducktape.utils.util import wait_until
+import time
+
+
+class CheckUtils(object):
+
+    def check_wait_until(self):
+        """Check normal wait until behavior"""
+        start = time.time()
+
+        wait_until(lambda: time.time() > start + .5, timeout_sec=2, backoff_sec=.1)
+
+    def check_wait_until_timeout(self):
+        """Check that timeout throws exception"""
+        start = time.time()
+
+        try:
+            wait_until(lambda: time.time() > start + 5, timeout_sec=.5, backoff_sec=.1)
+            raise Exception("This should have timed out")
+        except:
+            return

--- a/tests/utils/check_util.py
+++ b/tests/utils/check_util.py
@@ -30,7 +30,7 @@ class CheckUtils(object):
         start = time.time()
 
         try:
-            wait_until(lambda: time.time() > start + 5, timeout_sec=.5, backoff_sec=.1)
+            wait_until(lambda: time.time() > start + 5, timeout_sec=.5, backoff_sec=.1, err_msg="Hello world")
             raise Exception("This should have timed out")
-        except:
-            return
+        except Exception as e:
+            assert e.message == "Hello world"


### PR DESCRIPTION
@ewencp 
wait_until now raises an Exception with the desired error message instead of returning False if it times out