### PR TITLE
Postpone updating latest symlink until after tests run

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -108,7 +108,9 @@ def setup_results_directory(results_root, new_results_dir):
             "A file or directory at %s already exists. Exiting without overwriting." % new_results_dir)
     mkdir_p(new_results_dir)
 
-    # Create or update symlink "latest" which points to the new test results directory
+
+def update_latest_symlink(results_root, new_results_dir):
+    """Create or update symlink "latest" which points to the new test results directory"""
     latest_test_dir = os.path.join(results_root, "latest")
     if os.path.islink(latest_test_dir):
         os.unlink(latest_test_dir)
@@ -184,5 +186,6 @@ def main():
     reporter = HTMLSummaryReporter(test_results)
     reporter.report()
 
+    update_latest_symlink(args.results_root, results_dir)
     if not test_results.get_aggregate_success():
         sys.exit(1)

--- a/tests/command_line/check_main.py
+++ b/tests/command_line/check_main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ducktape.command_line.main import setup_results_directory
+from ducktape.command_line.main import update_latest_symlink
 
 import os
 import os.path
@@ -38,10 +39,12 @@ class CheckSetupResultsDirectory(object):
         """Check results and symlink from scratch"""
         assert not os.path.exists(self.results_dir)
         setup_results_directory(self.results_root, self.results_dir)
+        update_latest_symlink(self.results_root, self.results_dir)
         self.validate_directories()
 
     def check_symlink(self):
         """Check "latest" symlink behavior"""
+
         # if symlink already exists
         old_results = os.path.join(self.results_root, "OLD")
         os.mkdir(old_results)
@@ -49,10 +52,12 @@ class CheckSetupResultsDirectory(object):
         assert os.path.islink(self.latest_symlink) and os.path.exists(self.latest_symlink)
 
         setup_results_directory(self.results_root, self.results_dir)
+        update_latest_symlink(self.results_root, self.results_dir)
         self.validate_directories()
 
         # Try again if symlink exists and points to nothing
         os.rmdir(self.results_dir)
         assert os.path.islink(self.latest_symlink) and not os.path.exists(self.latest_symlink)
         setup_results_directory(self.results_root, self.results_dir)
+        update_latest_symlink(self.results_root, self.results_dir)
         self.validate_directories()


### PR DESCRIPTION
@ewencp Trivial fix - latest symlink is only updated after tests run and reports are created.