### PR TITLE
Added --compress option for compression of remote service logs

### DIFF
--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -29,6 +29,7 @@ def create_ducktape_parser():
     parser.add_argument("--debug", action="store_true", help="pipe more verbose test output to stdout.")
     parser.add_argument("--config-file", action="store", default=ConsoleDefaults.USER_CONFIG_FILE,
                         help="path to project-specific configuration file.")
+    parser.add_argument("--compress", action="store_true", help="compress remote logs before collection.")
     parser.add_argument("--cluster", action="store", default=ConsoleDefaults.CLUSTER_TYPE,
                         help="cluster class to use to allocate nodes for tests.")
     parser.add_argument("--cluster-file", action="store", default=None,

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -33,6 +33,7 @@ class SessionContext(Logger):
         self.cluster = kwargs["cluster"]
 
         self.debug = kwargs.get("debug", False)
+        self.compress = kwargs.get("compress", False)
         self.exit_first = kwargs.get("exit_first", False)
         self.no_teardown = kwargs.get("no_teardown", False)
         self._globals = kwargs.get("globals")

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -33,6 +33,12 @@ class RemoteAccountTestService(Service):
     def __init__(self, context):
         super(RemoteAccountTestService, self).__init__(context, 1)
         self.temp_dir = generate_tempdir_name()
+        self.logs = {
+            "my_log": {
+                "path": self.log_file,
+                "collect_default": True
+            }
+        }
 
     @property
     def log_file(self):

--- a/tests/tests/check_test.py
+++ b/tests/tests/check_test.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import random
+import shutil
+import tempfile
+
 from tests import ducktape_mock
-from ducktape.tests.test import Test, TestContext, _escape_pathname
+from ducktape.tests.test import Test, TestContext, _escape_pathname, _compress_cmd
 
 
 class CheckEscapePathname(object):
@@ -48,6 +53,93 @@ class CheckDescription(object):
         """If nobody has a docstring, there shouldn't be an error, and description should be empty string"""
         context = TestContext(session_context=ducktape_mock.session_context(), cls=DummyTestNoDescription, function=DummyTestNoDescription.test_this)
         assert context.description == ""
+
+
+class CheckCompressCmd(object):
+    """Check expected behavior of compress command used before collecting service logs"""
+    def setup_method(self, _):
+        self.tempdir = tempfile.mkdtemp()
+
+    def _make_random_file(self, dir, num_chars=10000):
+        """Populate filename with random characters."""
+        filename = os.path.join(dir, "f-%d" % random.randint(1, 2**63 - 1))
+        content = "".join([random.choice("0123456789abcdefghijklmnopqrstuvwxyz\n") for _ in range(num_chars)])
+        with open(filename, "w") as f:
+            f.writelines(content)
+        return filename
+
+    def _make_files(self, dir, num_files=10):
+        """Populate dir with several files with random characters."""
+        for i in range(num_files):
+            self._make_random_file(dir)
+
+    def _validate_compressed(self, uncompressed_path):
+        if uncompressed_path.endswith(os.path.sep):
+            uncompressed_path = uncompressed_path[:-len(os.path.sep)]
+
+        compressed_path = uncompressed_path + ".tgz"
+
+        # verify original file is replaced by filename.tgz
+        assert os.path.exists(compressed_path)
+        assert not os.path.exists(uncompressed_path)
+
+        # verify that uncompressing gets us back the original
+        os.chdir(self.tempdir)
+        os.system("tar xzf %s" % (compressed_path))
+        assert os.path.exists(uncompressed_path)
+
+    def check_abs_path_file(self):
+        """Check compress command on an absolute path to a file"""
+        filename = self._make_random_file(self.tempdir)
+        abspath_filename = os.path.abspath(filename)
+
+        # since we're using absolute path to file, we should be able to run the compress command from anywhere
+        tempdir2 = tempfile.mkdtemp(dir=self.tempdir)
+        os.chdir(tempdir2)
+        os.system(_compress_cmd(abspath_filename))
+        self._validate_compressed(abspath_filename)
+
+    def check_relative_path_file(self):
+        """Check compress command on a relative path to a file"""
+        filename = self._make_random_file(self.tempdir)
+        os.chdir(self.tempdir)
+        filename = os.path.basename(filename)
+        assert len(filename.split(os.path.sep)) == 1
+
+        # compress it!
+        os.system(_compress_cmd(filename))
+        self._validate_compressed(filename)
+
+    def check_abs_path_dir(self):
+        """Validate compress command with absolute path to a directory"""
+        dirname = tempfile.mkdtemp(dir=self.tempdir)
+        dirname = os.path.abspath(dirname)
+        self._make_files(dirname)
+
+        # compress it!
+        if not dirname.endswith(os.path.sep):
+            # extra check - ensure all of this works with trailing '/'
+            dirname += os.path.sep
+
+        os.system(_compress_cmd(dirname))
+        self._validate_compressed(dirname)
+
+    def check_relative_path_dir(self):
+        """Validate tarball compression of a directory"""
+        dirname = tempfile.mkdtemp(dir=self.tempdir)
+        self._make_files(dirname)
+
+        dirname = os.path.basename(dirname)
+        assert len(dirname.split(os.path.sep)) == 1
+
+        # compress it!
+        os.chdir(self.tempdir)
+        os.system(_compress_cmd(dirname))
+        self._validate_compressed(dirname)
+
+    def teardown_method(self, _):
+        if os.path.exists(self.tempdir):
+            shutil.rmtree(self.tempdir)
 
 
 class DummyTest(Test):


### PR DESCRIPTION
Allow possibility of compressing service logs before they are copied from remote workers