### PR TITLE
Added cluster methods for requesting and freeing subclusters

### DIFF
--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -38,7 +38,19 @@ class Cluster(object):
         """Size of this cluster object. I.e. number of 'nodes' in the cluster."""
         raise NotImplementedError()
 
-    def request(self, nslots):
+    def request_subcluster(self, num_nodes):
+        """Return an instance of Cluster with the specified num_nodes.
+
+        All implementations of this method within ducktape make use of the num_nodes parameter, but in some
+        conceivable implementations, it may be reasonable to ignore.
+        """
+        raise NotImplementedError()
+
+    def free_subcluster(self, subcluster):
+        """Free all nodes allocated to subcluster back to the original cluster."""
+        raise NotImplementedError()
+
+    def request(self, num_nodes):
         """Request the specified number of slots, which will be reserved until they are freed by the caller."""
         raise NotImplementedError()
 

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -22,15 +22,10 @@ class ClusterSlot(object):
             setattr(self, k, v)
 
     def __eq__(self, other):
-        if other is None:
-            return False
-
-        return self.__dict__ == other.__dict__
+        return other is not None and self.__dict__ == other.__dict__
 
     def __hash__(self):
-        # convert self.__dict__ to a hashable type
-        TupleRepresentation = collections.namedtuple('TupleRepresentation', [k for k in self.__dict__.keys()])
-        return hash(TupleRepresentation(**self.__dict__))
+        return hash(tuple(self.__dict__.items()))
 
 
 class Cluster(object):
@@ -43,14 +38,6 @@ class Cluster(object):
 
     def __len__(self):
         """Size of this cluster object. I.e. number of 'nodes' in the cluster."""
-        raise NotImplementedError()
-
-    def alloc_subcluster(self, num_nodes):
-        """Try to reserve num_nodes from this cluster, and return a cluster composed only of those nodes."""
-        raise NotImplementedError()
-
-    def free_subcluster(self, cluster):
-        """Free all nodes allocated to subcluster back to the original cluster."""
         raise NotImplementedError()
 
     def alloc(self, num_nodes):
@@ -77,7 +64,7 @@ class Cluster(object):
         raise NotImplementedError()
 
     def __eq__(self, other):
-        if other is None:
-            return False
+        return other is not None and self.__dict__ == other.__dict__
 
-        return self.__dict__ == other.__dict__
+    def __hash__(self):
+        return hash(tuple(self.__dict__.items()))

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -16,14 +16,22 @@ import collections
 
 
 class ClusterSlot(object):
-    def __init__(self, parent, account, **kwargs):
-        self.parent = parent
+    def __init__(self, account, **kwargs):
         self.account = account
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    def free(self):
-        self.parent.free(self)
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __hash__(self):
+        # convert self.__dict__ to a hashable type
+        TupleRepresentation = collections.namedtuple('TupleRepresentation', [k for k in self.__dict__.keys()])
+        return hash(TupleRepresentation(**self.__dict__))
+
 
 
 class Cluster(object):
@@ -68,3 +76,9 @@ class Cluster(object):
 
     def free_single(self, slot):
         raise NotImplementedError()
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -25,7 +25,7 @@ class ClusterSlot(object):
         return other is not None and self.__dict__ == other.__dict__
 
     def __hash__(self):
-        return hash(tuple(self.__dict__.items()))
+        return hash(tuple(sorted(self.__dict__.items())))
 
 
 class Cluster(object):
@@ -67,4 +67,4 @@ class Cluster(object):
         return other is not None and self.__dict__ == other.__dict__
 
     def __hash__(self):
-        return hash(tuple(self.__dict__.items()))
+        return hash(tuple(sorted(self.__dict__.items())))

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -33,7 +33,6 @@ class ClusterSlot(object):
         return hash(TupleRepresentation(**self.__dict__))
 
 
-
 class Cluster(object):
     """ Interface for a cluster -- a collection of nodes with login credentials.
     This interface doesn't define any mapping of roles/services to nodes. It only interacts with some underlying
@@ -46,35 +45,35 @@ class Cluster(object):
         """Size of this cluster object. I.e. number of 'nodes' in the cluster."""
         raise NotImplementedError()
 
-    def request_subcluster(self, num_nodes):
-        """Return an instance of Cluster with the specified num_nodes.
-
-        All implementations of this method within ducktape make use of the num_nodes parameter, but in some
-        conceivable implementations, it may be reasonable to ignore.
-        """
+    def alloc_subcluster(self, num_nodes):
+        """Try to reserve num_nodes from this cluster, and return a cluster composed only of those nodes."""
         raise NotImplementedError()
 
-    def free_subcluster(self, subcluster):
+    def free_subcluster(self, cluster):
         """Free all nodes allocated to subcluster back to the original cluster."""
         raise NotImplementedError()
 
-    def request(self, num_nodes):
-        """Request the specified number of slots, which will be reserved until they are freed by the caller."""
+    def alloc(self, num_nodes):
+        """Try to allocate the specified number of nodes, which will be reserved until they are freed by the caller."""
         raise NotImplementedError()
+
+    def request(self, num_nodes):
+        """Identical to alloc. Keeping for compatibility"""
+        return self.alloc(num_nodes)
 
     def num_available_nodes(self):
-        """Number of available slots."""
+        """Number of available nodes."""
         raise NotImplementedError()
 
-    def free(self, slots):
-        """Free the given slot or list of slots"""
-        if isinstance(slots, collections.Iterable):
-            for s in slots:
+    def free(self, nodes):
+        """Free the given node or list of nodes"""
+        if isinstance(nodes, collections.Iterable):
+            for s in nodes:
                 self.free_single(s)
         else:
-            self.free_single(slots)
+            self.free_single(nodes)
 
-    def free_single(self, slot):
+    def free_single(self, node):
         raise NotImplementedError()
 
     def __eq__(self, other):

--- a/ducktape/cluster/finite_subcluster.py
+++ b/ducktape/cluster/finite_subcluster.py
@@ -18,8 +18,8 @@ from ducktape.cluster.cluster import Cluster
 class FiniteSubcluster(Cluster):
     """This cluster class gives us a mechanism for allocating finite blocks of nodes from another cluster.
     """
-    def __init__(self, node_list):
-        self.nodes = node_list
+    def __init__(self, nodes):
+        self.nodes = nodes
         self._available = set(self.nodes)
         self._in_use = set()
 

--- a/ducktape/cluster/finite_subcluster.py
+++ b/ducktape/cluster/finite_subcluster.py
@@ -1,0 +1,51 @@
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.cluster.cluster import Cluster
+
+
+class FiniteSubcluster(Cluster):
+    """This cluster class gives us a mechanism for allocating finite blocks of nodes from another cluster.
+    """
+    def __init__(self, node_list):
+        self.nodes = node_list
+        self._available = set(self.nodes)
+        self._in_use = set()
+
+    def __len__(self):
+        """Size of this cluster object. I.e. number of 'nodes' in the cluster."""
+        return len(self.nodes)
+
+    def alloc(self, num_nodes):
+        assert num_nodes <= self.num_available_nodes()
+
+        allocated_nodes = []
+        for _ in range(num_nodes):
+            node = self._available.pop()
+            self._in_use.add(node)
+
+            allocated_nodes.append(node)
+
+        return allocated_nodes
+
+    def num_available_nodes(self):
+        """Number of available nodes."""
+        return len(self._available)
+
+    def free_single(self, node):
+        assert node in self._in_use
+        self._in_use.remove(node)
+        self._available.add(node)
+
+

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -87,15 +87,6 @@ class JsonCluster(Cluster):
     def num_available_nodes(self):
         return len(self.available_nodes)
 
-    def _account_to_dict(self, account):
-        return {
-            "hostname": account.hostname,
-            "user": account.user,
-            "ssh_args": account.ssh_args,
-            "ssh_hostname": account.ssh_hostname,
-            "externally_routable_ip": account.externally_routable_ip
-        }
-
     def alloc(self, num_nodes):
         if num_nodes > self.num_available_nodes():
             err_msg = "There aren't enough available nodes to satisfy the resource request. " \

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -86,15 +86,15 @@ class JsonCluster(Cluster):
     def num_available_nodes(self):
         return len(self.available_nodes)
 
-    def request_subcluster(self, num_nodes):
-        nodes = self.request(num_nodes)
+    def alloc_subcluster(self, num_nodes):
+        nodes = self.alloc(num_nodes)
         return JsonCluster(
             cluster_json={
                 "nodes": [self._account_to_dict(n.account) for n in nodes]
             })
 
-    def free_subcluster(self, subcluster):
-        nodes = subcluster.request(len(subcluster))
+    def free_subcluster(self, cluster):
+        nodes = cluster.alloc(len(cluster))
         self.free(nodes)
 
     def _account_to_dict(self, account):
@@ -106,7 +106,7 @@ class JsonCluster(Cluster):
             "externally_routable_ip": account.externally_routable_ip
         }
 
-    def request(self, num_nodes):
+    def alloc(self, num_nodes):
         if num_nodes > self.num_available_nodes():
             err_msg = "There aren't enough available nodes to satisfy the resource request. " \
                 "Total cluster size: %d, Requested: %d, Already allocated: %d, Available: %d. " % \

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -17,7 +17,9 @@ from __future__ import absolute_import
 from ducktape.command_line.defaults import ConsoleDefaults
 from .cluster import Cluster, ClusterSlot
 from .remoteaccount import RemoteAccount
-import collections, json, os, os.path
+import collections
+import json
+import os
 
 
 class JsonCluster(Cluster):
@@ -77,7 +79,6 @@ class JsonCluster(Cluster):
 
         self.available_nodes = collections.deque(node_accounts)
         self.in_use_nodes = set()
-        self.id_source = 1
 
     def __len__(self):
         return len(self.available_nodes) + len(self.in_use_nodes)
@@ -101,7 +102,7 @@ class JsonCluster(Cluster):
             "hostname": account.hostname,
             "user": account.user,
             "ssh_args": account.ssh_args,
-            "ssh_hostname": account.hostname,
+            "ssh_hostname": account.ssh_hostname,
             "externally_routable_ip": account.externally_routable_ip
         }
 
@@ -116,14 +117,14 @@ class JsonCluster(Cluster):
         result = []
         for i in range(num_nodes):
             node = self.available_nodes.popleft()
-            result.append(ClusterSlot(self, node, slot_id=self.id_source))
-            self.in_use_nodes.add(self.id_source)
-            self.id_source += 1
+            cluster_slot = ClusterSlot(node)
+            result.append(cluster_slot)
+            self.in_use_nodes.add(cluster_slot)
         return result
 
     def free_single(self, slot):
-        assert(slot.slot_id in self.in_use_nodes)
-        self.in_use_nodes.remove(slot.slot_id)
+        assert(slot in self.in_use_nodes)
+        self.in_use_nodes.remove(slot)
         self.available_nodes.append(slot.account)
 
     def _externally_routable_ip(self, account):

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -43,7 +43,7 @@ class LocalhostCluster(Cluster):
     def request(self, num_nodes):
         assert self._available >= num_nodes
         self._available -= num_nodes
-        return [ClusterSlot(self, RemoteAccount("localhost")) for i in range(num_nodes)]
+        return [ClusterSlot(RemoteAccount("localhost")) for i in range(num_nodes)]
 
     def num_available_nodes(self):
         return self._available

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -28,22 +28,20 @@ class LocalhostCluster(Cluster):
         # Use a very large number, but fixed value so accounting for # of available nodes works
         self._size = kwargs.get("num_nodes", sys.maxint)
         self._available = self._size
+        self._id_supplier = 0
 
     def __len__(self):
         return self._size
 
-    def alloc_subcluster(self, num_nodes):
-        self.alloc(num_nodes)
-        return LocalhostCluster(num_nodes=num_nodes)
-
-    def free_subcluster(self, cluster):
-        nodes = cluster.alloc(len(cluster))
-        self.free(nodes)
-
     def alloc(self, num_nodes):
         assert self._available >= num_nodes
         self._available -= num_nodes
-        return [ClusterSlot(RemoteAccount("localhost")) for i in range(num_nodes)]
+
+        allocated_nodes = []
+        for _ in range(num_nodes):
+            allocated_nodes.append(ClusterSlot(RemoteAccount("localhost"), slot_id=self._id_supplier))
+            self._id_supplier += 1
+        return allocated_nodes
 
     def num_available_nodes(self):
         return self._available

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -32,15 +32,15 @@ class LocalhostCluster(Cluster):
     def __len__(self):
         return self._size
 
-    def request_subcluster(self, num_nodes):
-        self.request(num_nodes)
+    def alloc_subcluster(self, num_nodes):
+        self.alloc(num_nodes)
         return LocalhostCluster(num_nodes=num_nodes)
 
-    def free_subcluster(self, subcluster):
-        nodes = subcluster.request(len(subcluster))
+    def free_subcluster(self, cluster):
+        nodes = cluster.alloc(len(cluster))
         self.free(nodes)
 
-    def request(self, num_nodes):
+    def alloc(self, num_nodes):
         assert self._available >= num_nodes
         self._available -= num_nodes
         return [ClusterSlot(RemoteAccount("localhost")) for i in range(num_nodes)]

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -26,17 +26,28 @@ class LocalhostCluster(Cluster):
 
     def __init__(self, *args, **kwargs):
         # Use a very large number, but fixed value so accounting for # of available nodes works
-        self._available = sys.maxint
+        self._size = kwargs.get("num_nodes", sys.maxint)
+        self._available = self._size
 
     def __len__(self):
-        return sys.maxint
+        return self._size
 
-    def request(self, nslots):
-        self._available -= nslots
-        return [ClusterSlot(self, RemoteAccount("localhost")) for i in range(nslots)]
+    def request_subcluster(self, num_nodes):
+        self.request(num_nodes)
+        return LocalhostCluster(num_nodes=num_nodes)
+
+    def free_subcluster(self, subcluster):
+        nodes = subcluster.request(len(subcluster))
+        self.free(nodes)
+
+    def request(self, num_nodes):
+        assert self._available >= num_nodes
+        self._available -= num_nodes
+        return [ClusterSlot(self, RemoteAccount("localhost")) for i in range(num_nodes)]
 
     def num_available_nodes(self):
         return self._available
 
     def free_single(self, slot):
+        assert self._available + 1 <= self._size
         self._available += 1

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -47,7 +47,7 @@ class RemoteAccount(HttpMixin):
         return other is not None and self.__dict__ == other.__dict__
 
     def __hash__(self):
-        return hash(tuple(self.__dict__.items()))
+        return hash(tuple(sorted(self.__dict__.items())))
 
     @property
     def local(self):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -44,15 +44,10 @@ class RemoteAccount(HttpMixin):
         return str(self.__dict__)
 
     def __eq__(self, other):
-        if other is None:
-            return False
-
-        return self.__dict__ == other.__dict__
+        return other is not None and self.__dict__ == other.__dict__
 
     def __hash__(self):
-        # convert self.__dict__ to a hashable type
-        TupleRepresentation = collections.namedtuple('TupleRepresentation', [k for k in self.__dict__.keys()])
-        return hash(TupleRepresentation(**self.__dict__))
+        return hash(tuple(self.__dict__.items()))
 
     @property
     def local(self):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import os
 import select
 import signal
@@ -38,6 +39,20 @@ class RemoteAccount(HttpMixin):
             r += self.user + "@"
         r += self.hostname
         return r
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __hash__(self):
+        # convert self.__dict__ to a hashable type
+        TupleRepresentation = collections.namedtuple('TupleRepresentation', [k for k in self.__dict__.keys()])
+        return hash(TupleRepresentation(**self.__dict__))
 
     @property
     def local(self):
@@ -280,6 +295,7 @@ class iter_wrapper(object):
             if timeout_sec is None or select.select([self.descriptor], [], [], timeout_sec)[0]:
                 self.cached = next(self.iter_obj, self.sentinel)
         return self.cached is not self.sentinel
+
 
 class LogMonitor(object):
     """

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -24,7 +24,7 @@ from ducktape.utils.util import wait_until
 
 
 class RemoteAccount(HttpMixin):
-    def __init__(self, hostname, user=None, ssh_args=None, ssh_hostname=None, externally_routable_ip = None, logger=None):
+    def __init__(self, hostname, user=None, ssh_args=None, ssh_hostname=None, externally_routable_ip=None, logger=None):
         self.hostname = hostname
         self.user = user
         self.ssh_args = ssh_args

--- a/ducktape/cluster/vagrant.py
+++ b/ducktape/cluster/vagrant.py
@@ -121,6 +121,7 @@ class VagrantCluster(JsonCluster):
             output, _ = proc.communicate()
             self._is_aws = output.find("aws") >= 0
         return self._is_aws
+
     def _externally_routable_ip(self, node_account):
         if self.is_aws:
             cmd = "/sbin/ifconfig eth0 "

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -197,7 +197,6 @@ class Service(TemplateRenderer):
             raise TimeoutError("Timed out waiting %s seconds for service nodes to finish. " % str(timeout_sec) +
                                "These nodes are still alive: " + str(unfinished_nodes))
 
-
     def wait_node(self, node, timeout_sec=None):
         """Wait for the service on the given node to finish. 
         Return True if the node finished shutdown, False otherwise.
@@ -236,7 +235,7 @@ class Service(TemplateRenderer):
         for node in self.nodes:
             self.logger.info("%s: freeing node" % self.who_am_i(node))
             node.account.logger = None
-            node.free()
+            self.cluster.free(node)
 
         self.nodes = []
 

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -128,7 +128,7 @@ class Service(TemplateRenderer):
         self.logger.debug("Requesting %d nodes from the cluster." % self.num_nodes)
 
         try:
-            self.nodes = self.cluster.request(self.num_nodes)
+            self.nodes = self.cluster.alloc(self.num_nodes)
         except RuntimeError as e:
             msg = str(e.message)
             if hasattr(self.context, "services"):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -127,7 +127,7 @@ class TestRunner(object):
             # If there is no information on cluster usage, allocate entire cluster
             expected_num_nodes = len(self.cluster)
 
-        self.test_id_to_cluster[test_context.test_id] = self.cluster.request_subcluster(expected_num_nodes)
+        self.test_id_to_cluster[test_context.test_id] = self.cluster.alloc_subcluster(expected_num_nodes)
 
     def _handle(self, event):
         self._log(logging.DEBUG, str(event))

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -124,7 +124,8 @@ class TestRunner(object):
 
         expected_num_nodes = test_context.expected_num_nodes
         if expected_num_nodes is None:
-            expected_num_nodes = min(len(self.cluster), 10000)
+            # If there is no information on cluster usage, allocate entire cluster
+            expected_num_nodes = len(self.cluster)
 
         self.test_id_to_cluster[test_context.test_id] = self.cluster.request_subcluster(expected_num_nodes)
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -126,6 +126,10 @@ class TestRunner(object):
         expected_num_nodes = test_context.expected_num_nodes
         if expected_num_nodes is None:
             # If there is no information on cluster usage, allocate entire cluster
+            if self.session_context.max_parallel > 1:
+                self._log(logging.WARNING,
+                          "Test %s has no cluster use metadata, so this test will not run in parallel with any others."
+                          % test_context.test_id)
             expected_num_nodes = len(self.cluster)
 
         self._test_cluster[test_context.test_id] = FiniteSubcluster(self.cluster.alloc(expected_num_nodes))

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -73,12 +73,6 @@ class RunnerClient(object):
         self.test_context = self._collect_test_context(**self.test_metadata)
 
         self.send(self.message.running())
-        if len(self.cluster) != self.cluster.num_available_nodes():
-            # Sanity check - are we leaking cluster nodes?
-            raise RuntimeError(
-                "Expected all nodes to be available. Instead, %d of %d are available" %
-                (self.cluster.num_available_nodes(), len(self.cluster)))
-
         if self.test_context.ignore:
             # Skip running this test, but keep track of the fact that we ignored it
             result = TestResult(self.test_context,

--- a/tests/cluster/check_cluster.py
+++ b/tests/cluster/check_cluster.py
@@ -1,0 +1,39 @@
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ducktape.cluster.cluster import ClusterSlot
+from ducktape.cluster.remoteaccount import RemoteAccount
+
+import logging
+
+
+class CheckClusterSlot(object):
+    def check_cluster_slot_equality(self):
+        """Different cluster slots intantiated with same parameters should be equal."""
+        kwargs = {
+            "hostname": "hello",
+            "user": "vagrant",
+            "ssh_args": "asdf",
+            "ssh_hostname": "123",
+            "externally_routable_ip": "345",
+            "logger": logging.getLogger(__name__)
+        }
+        r1 = RemoteAccount(**kwargs)
+        r2 = RemoteAccount(**kwargs)
+
+        c1 = ClusterSlot(account=r1)
+        c2 = ClusterSlot(account=r2)
+
+        assert c1 == c2

--- a/tests/cluster/check_finite_subcluster.py
+++ b/tests/cluster/check_finite_subcluster.py
@@ -1,0 +1,69 @@
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.cluster.finite_subcluster import FiniteSubcluster
+import pickle
+import pytest
+
+
+class CheckFiniteSubcluster(object):
+    single_node_cluster_json = {"nodes": [{"hostname": "localhost"}]}
+
+    def check_cluster_size(self):
+        cluster = FiniteSubcluster([])
+        assert len(cluster) == 0
+
+        n = 10
+        cluster = FiniteSubcluster([object() for _ in range(n)])
+        assert len(cluster) == n
+
+    def check_pickleable(self):
+        cluster = FiniteSubcluster([object() for _ in range(10)])
+        pickle.dumps(cluster)
+
+    def check_allocate_free(self):
+        n = 10
+        cluster = FiniteSubcluster([object() for _ in range(n)])
+        assert len(cluster) == n
+        assert cluster.num_available_nodes() == n
+
+        nodes = cluster.alloc(1)
+        assert len(nodes) == 1
+        assert len(cluster) == n
+        assert cluster.num_available_nodes() == n - 1
+
+        nodes2 = cluster.alloc(2)
+        assert len(nodes2) == 2
+        assert len(cluster) == n
+        assert cluster.num_available_nodes() == n - 3
+
+        cluster.free(nodes)
+        assert cluster.num_available_nodes() == n - 2
+
+        cluster.free(nodes2)
+        assert cluster.num_available_nodes() == n
+
+    def check_alloc_too_many(self):
+        n = 10
+        cluster = FiniteSubcluster([object() for _ in range(n)])
+        with pytest.raises(AssertionError):
+            cluster.alloc(n + 1)
+
+    def check_free_too_many(self):
+        n = 10
+        cluster = FiniteSubcluster([object() for _ in range(n)])
+        nodes = cluster.alloc(n)
+        with pytest.raises(AssertionError):
+            nodes.append(object())
+            cluster.free(nodes)

--- a/tests/cluster/check_json.py
+++ b/tests/cluster/check_json.py
@@ -45,34 +45,6 @@ class CheckJsonCluster(object):
         cluster = JsonCluster({"nodes":[{"hostname": "localhost1"}, {"hostname": "localhost2"}, {"hostname": "localhost3"}]})
         pickle.dumps(cluster)
 
-    def check_request_free_subcluster(self):
-        """Check that requesting and freeing a subcluster behaves correctly."""
-        cluster_size = 100
-        cluster_json = {
-            "nodes": [{"hostname": "localhost%d" % i} for i in range(cluster_size)]
-        }
-        cluster = JsonCluster(cluster_json)
-        cluster_initial_size = len(cluster)
-        subcluster_size = 10
-        subcluster = cluster.alloc_subcluster(subcluster_size)
-
-        assert isinstance(subcluster, JsonCluster)
-        assert cluster.num_available_nodes() == cluster_initial_size - subcluster_size
-        assert len(subcluster) == subcluster_size
-
-        cluster.free_subcluster(subcluster)
-        assert cluster.num_available_nodes() == cluster_initial_size
-
-    def check_request_subcluster_disjoint(self):
-        cluster_size = 100
-        cluster_json = {
-            "nodes": [{"hostname": "localhost%d" % i} for i in range(cluster_size)]
-        }
-        cluster = JsonCluster(cluster_json)
-        cluster_initial_size = len(cluster)
-        subcluster_size = 10
-        subcluster = cluster.alloc_subcluster(subcluster_size)
-
     def check_allocate_free(self):
         cluster = JsonCluster({"nodes":[{"hostname": "localhost1"}, {"hostname": "localhost2"}, {"hostname": "localhost3"}]})
         assert len(cluster) == 3

--- a/tests/cluster/check_json.py
+++ b/tests/cluster/check_json.py
@@ -45,6 +45,34 @@ class CheckJsonCluster(object):
         cluster = JsonCluster({"nodes":[{"hostname": "localhost1"}, {"hostname": "localhost2"}, {"hostname": "localhost3"}]})
         pickle.dumps(cluster)
 
+    def check_request_free_subcluster(self):
+        """Check that requesting and freeing a subcluster behaves correctly."""
+        cluster_size = 100
+        cluster_json = {
+            "nodes": [{"hostname": "localhost%d" % i} for i in range(cluster_size)]
+        }
+        cluster = JsonCluster(cluster_json)
+        cluster_initial_size = len(cluster)
+        subcluster_size = 10
+        subcluster = cluster.request_subcluster(subcluster_size)
+
+        assert isinstance(subcluster, JsonCluster)
+        assert cluster.num_available_nodes() == cluster_initial_size - subcluster_size
+        assert len(subcluster) == subcluster_size
+
+        cluster.free_subcluster(subcluster)
+        assert cluster.num_available_nodes() == cluster_initial_size
+
+    def check_request_subcluster_disjoint(self):
+        cluster_size = 100
+        cluster_json = {
+            "nodes": [{"hostname": "localhost%d" % i} for i in range(cluster_size)]
+        }
+        cluster = JsonCluster(cluster_json)
+        cluster_initial_size = len(cluster)
+        subcluster_size = 10
+        subcluster = cluster.request_subcluster(subcluster_size)
+
     def check_allocate_free(self):
         cluster = JsonCluster({"nodes":[{"hostname": "localhost1"}, {"hostname": "localhost2"}, {"hostname": "localhost3"}]})
         assert len(cluster) == 3

--- a/tests/cluster/check_json.py
+++ b/tests/cluster/check_json.py
@@ -54,7 +54,7 @@ class CheckJsonCluster(object):
         cluster = JsonCluster(cluster_json)
         cluster_initial_size = len(cluster)
         subcluster_size = 10
-        subcluster = cluster.request_subcluster(subcluster_size)
+        subcluster = cluster.alloc_subcluster(subcluster_size)
 
         assert isinstance(subcluster, JsonCluster)
         assert cluster.num_available_nodes() == cluster_initial_size - subcluster_size
@@ -71,19 +71,19 @@ class CheckJsonCluster(object):
         cluster = JsonCluster(cluster_json)
         cluster_initial_size = len(cluster)
         subcluster_size = 10
-        subcluster = cluster.request_subcluster(subcluster_size)
+        subcluster = cluster.alloc_subcluster(subcluster_size)
 
     def check_allocate_free(self):
         cluster = JsonCluster({"nodes":[{"hostname": "localhost1"}, {"hostname": "localhost2"}, {"hostname": "localhost3"}]})
         assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 3)
 
-        nodes = cluster.request(1)
+        nodes = cluster.alloc(1)
         nodes_hostnames = self.cluster_hostnames(nodes)
         assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 2)
 
-        nodes2 = cluster.request(2)
+        nodes2 = cluster.alloc(2)
         nodes2_hostnames = self.cluster_hostnames(nodes2)
         assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 0)
@@ -98,14 +98,14 @@ class CheckJsonCluster(object):
 
     def check_parsing(self):
         # Checks that RemoteAccounts are generated correctly from input JSON
-        node = JsonCluster({"nodes":[{"hostname": "hostname"}]}).request(1)[0]
+        node = JsonCluster({"nodes":[{"hostname": "hostname"}]}).alloc(1)[0]
         assert(node.account.hostname == "hostname")
         assert(node.account.user is None)
         assert(node.account.ssh_args is None)
 
         node = JsonCluster({"nodes":[{"hostname": "hostname",
                                       "user": "user",
-                                      "ssh_args": "ssh_args"}]}).request(1)[0]
+                                      "ssh_args": "ssh_args"}]}).alloc(1)[0]
         assert(node.account.hostname == "hostname")
         assert(node.account.user == "user")
         assert(node.account.ssh_args == "ssh_args")
@@ -113,4 +113,4 @@ class CheckJsonCluster(object):
     def check_exhausts_supply(self):
         cluster = JsonCluster(self.single_node_cluster_json)
         with pytest.raises(RuntimeError):
-            cluster.request(2)
+            cluster.alloc(2)

--- a/tests/cluster/check_localhost.py
+++ b/tests/cluster/check_localhost.py
@@ -18,7 +18,7 @@ import pickle
 
 
 class CheckLocalhostCluster(object):
-    def setup_method(self, method):
+    def setup_method(self, _):
         self.cluster = LocalhostCluster()
 
     def check_size(self):
@@ -27,23 +27,6 @@ class CheckLocalhostCluster(object):
     def check_pickleable(self):
         cluster = LocalhostCluster()
         pickle.dumps(cluster)
-
-    def check_request_free_subcluster(self):
-        cluster_initial_size = len(self.cluster)
-        subcluster_size = 100
-        subcluster = self.cluster.alloc_subcluster(subcluster_size)
-
-        assert isinstance(subcluster, LocalhostCluster)
-        assert self.cluster.num_available_nodes() == cluster_initial_size - subcluster_size
-        assert len(subcluster) == subcluster_size
-
-        self.cluster.free_subcluster(subcluster)
-        assert self.cluster.num_available_nodes() == cluster_initial_size
-
-    def check_subcluster_size(self):
-        cluster = LocalhostCluster()
-        subcluster = cluster.alloc_subcluster(10)
-        assert len(subcluster) == 10
 
     def check_request_free(self):
         available = self.cluster.num_available_nodes()

--- a/tests/cluster/check_localhost.py
+++ b/tests/cluster/check_localhost.py
@@ -40,6 +40,11 @@ class CheckLocalhostCluster(object):
         self.cluster.free_subcluster(subcluster)
         assert self.cluster.num_available_nodes() == cluster_initial_size
 
+    def check_subcluster_size(self):
+        cluster = LocalhostCluster()
+        subcluster = cluster.request_subcluster(10)
+        assert len(subcluster) == 10
+
     def check_request_free(self):
         available = self.cluster.num_available_nodes()
         initial_size = len(self.cluster)

--- a/tests/cluster/check_localhost.py
+++ b/tests/cluster/check_localhost.py
@@ -28,6 +28,18 @@ class CheckLocalhostCluster(object):
         cluster = LocalhostCluster()
         pickle.dumps(cluster)
 
+    def check_request_free_subcluster(self):
+        cluster_initial_size = len(self.cluster)
+        subcluster_size = 100
+        subcluster = self.cluster.request_subcluster(subcluster_size)
+
+        assert isinstance(subcluster, LocalhostCluster)
+        assert self.cluster.num_available_nodes() == cluster_initial_size - subcluster_size
+        assert len(subcluster) == subcluster_size
+
+        self.cluster.free_subcluster(subcluster)
+        assert self.cluster.num_available_nodes() == cluster_initial_size
+
     def check_request_free(self):
         available = self.cluster.num_available_nodes()
         initial_size = len(self.cluster)

--- a/tests/cluster/check_localhost.py
+++ b/tests/cluster/check_localhost.py
@@ -31,7 +31,7 @@ class CheckLocalhostCluster(object):
     def check_request_free_subcluster(self):
         cluster_initial_size = len(self.cluster)
         subcluster_size = 100
-        subcluster = self.cluster.request_subcluster(subcluster_size)
+        subcluster = self.cluster.alloc_subcluster(subcluster_size)
 
         assert isinstance(subcluster, LocalhostCluster)
         assert self.cluster.num_available_nodes() == cluster_initial_size - subcluster_size
@@ -42,7 +42,7 @@ class CheckLocalhostCluster(object):
 
     def check_subcluster_size(self):
         cluster = LocalhostCluster()
-        subcluster = cluster.request_subcluster(10)
+        subcluster = cluster.alloc_subcluster(10)
         assert len(subcluster) == 10
 
     def check_request_free(self):
@@ -50,7 +50,7 @@ class CheckLocalhostCluster(object):
         initial_size = len(self.cluster)
 
         # Should be able to allocate arbitrarily many nodes
-        slots = self.cluster.request(100)
+        slots = self.cluster.alloc(100)
         assert(len(slots) == 100)
         for slot in slots:
             assert(slot.account.hostname == 'localhost')

--- a/tests/cluster/check_remoteaccount.py
+++ b/tests/cluster/check_remoteaccount.py
@@ -15,13 +15,16 @@
 from ducktape.errors import TimeoutError
 from tests.ducktape_mock import MockAccount
 from tests.test_utils import find_available_port
+from ducktape.cluster.remoteaccount import RemoteAccount
 
+import logging
 from threading import Thread
 import SimpleHTTPServer
 import SocketServer
 import threading
 import time
 import random
+
 
 class SimpleServer(object):
     """Helper class which starts a simple server listening on localhost at the specified port
@@ -53,7 +56,6 @@ class SimpleServer(object):
         self.background_thread.join(timeout=.5)
         if self.background_thread.is_alive():
             raise Exception("SimpleServer failed to stop quickly")
-
 
 
 class CheckIterWrapper(object):
@@ -91,6 +93,7 @@ class CheckIterWrapper(object):
     def teardown(self):
         self.account.ssh("rm -f " + self.temp_file)
 
+
 class CheckRemoteAccount(object):
     def setup(self):
         self.server = SimpleServer()
@@ -120,4 +123,21 @@ class CheckRemoteAccount(object):
 
     def teardown(self):
         self.server.stop()
+
+
+class CheckRemoteAccountEquality(object):
+    def check_remote_account_equality(self):
+        """Different instances of remote account initialized with the same parameters should be equal."""
+        kwargs = {
+            "hostname": "hello",
+            "user": "vagrant",
+            "ssh_args": "asdf",
+            "ssh_hostname": "123",
+            "externally_routable_ip": "345",
+            "logger": logging.getLogger(__name__)
+        }
+        r1 = RemoteAccount(**kwargs)
+        r2 = RemoteAccount(**kwargs)
+
+        assert r1 == r2
 

--- a/tests/cluster/check_vagrant.py
+++ b/tests/cluster/check_vagrant.py
@@ -74,7 +74,7 @@ class CheckVagrantCluster(object):
         cluster = VagrantCluster()
         assert len(cluster) == 2
         assert cluster.num_available_nodes() == 2
-        node1, node2 = cluster.request(2)
+        node1, node2 = cluster.alloc(2)
 
         assert node1.account.hostname == "worker1"
         assert node1.account.user == "vagrant"
@@ -138,7 +138,7 @@ class CheckVagrantCluster(object):
 
         assert len(cluster) == 2
         assert cluster.num_available_nodes() == 2
-        node1, node2 = cluster.request(2)
+        node1, node2 = cluster.alloc(2)
 
         assert node1.account.hostname == "worker2"
         assert node1.account.user == "vagrant"

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -20,7 +20,7 @@ from ducktape.cluster.localhost import LocalhostCluster
 import tests.ducktape_mock
 from .resources.test_thingy import TestThingy
 
-from mock import MagicMock, Mock
+from mock import Mock
 import os
 
 TEST_THINGY_FILE = os.path.abspath(
@@ -53,7 +53,7 @@ class FakeCluster(object):
     def free(self, slots):
         self._available_nodes += len(slots)
 
-    def free_single(self, slot):
+    def free_single(self, _):
         self._available_nodes += 1
 
 
@@ -78,7 +78,7 @@ class CheckRunner(object):
 
     def check_simple_run(self):
         """Check expected behavior when running a single test."""
-        mock_cluster = LocalhostCluster()
+        mock_cluster = LocalhostCluster(num_nodes=1000)
         session_context = tests.ducktape_mock.session_context()
 
         test_methods = [TestThingy.test_pi, TestThingy.test_ignore1, TestThingy.test_ignore2]

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -40,6 +40,13 @@ class FakeCluster(object):
         self._available_nodes -= nslots
         return [object() for _ in range(nslots)]
 
+    def request_subcluster(self, nslots):
+        self.request(nslots)
+        return FakeCluster(nslots)
+
+    def free_subcluster(self, subcluster):
+        self.free(subcluster.request(len(subcluster)))
+
     def num_available_nodes(self):
         return self._available_nodes
 

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -45,7 +45,7 @@ class FakeCluster(object):
         return FakeCluster(nslots)
 
     def free_subcluster(self, subcluster):
-        self.free(subcluster.request(len(subcluster)))
+        self.free(subcluster.alloc(len(subcluster)))
 
     def num_available_nodes(self):
         return self._available_nodes

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -16,6 +16,7 @@ from ducktape.tests.test import TestContext
 from ducktape.tests.runner import TestRunner
 from ducktape.mark.mark_expander import MarkedFunctionExpander
 from ducktape.cluster.localhost import LocalhostCluster
+from ducktape.cluster.cluster import Cluster
 
 import tests.ducktape_mock
 from .resources.test_thingy import TestThingy
@@ -27,7 +28,7 @@ TEST_THINGY_FILE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "resources/test_thingy.py"))
 
 
-class FakeCluster(object):
+class FakeCluster(Cluster):
     def __init__(self, num_nodes):
         self._num_nodes = num_nodes
         self._available_nodes = self._num_nodes
@@ -35,13 +36,13 @@ class FakeCluster(object):
     def __len__(self):
         return self._num_nodes
 
-    def request(self, nslots):
+    def alloc(self, nslots):
         """Request the specified number of slots, which will be reserved until they are freed by the caller."""
         self._available_nodes -= nslots
         return [object() for _ in range(nslots)]
 
-    def request_subcluster(self, nslots):
-        self.request(nslots)
+    def alloc_subcluster(self, nslots):
+        self.alloc(nslots)
         return FakeCluster(nslots)
 
     def free_subcluster(self, subcluster):

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -41,13 +41,6 @@ class FakeCluster(Cluster):
         self._available_nodes -= nslots
         return [object() for _ in range(nslots)]
 
-    def alloc_subcluster(self, nslots):
-        self.alloc(nslots)
-        return FakeCluster(nslots)
-
-    def free_subcluster(self, subcluster):
-        self.free(subcluster.alloc(len(subcluster)))
-
     def num_available_nodes(self):
         return self._available_nodes
 

--- a/tests/runner/check_runner_memory.py
+++ b/tests/runner/check_runner_memory.py
@@ -60,7 +60,7 @@ class InstrumentedTestRunner(TestRunner):
 
 class CheckMemoryUsage(object):
     def setup_method(self, _):
-        self.cluster = LocalhostCluster()
+        self.cluster = LocalhostCluster(num_nodes=100)
         self.session_context = tests.ducktape_mock.session_context()
 
     def check_for_inter_test_memory_leak(self):

--- a/tests/runner/check_runner_memory.py
+++ b/tests/runner/check_runner_memory.py
@@ -48,13 +48,13 @@ class InstrumentedTestRunner(TestRunner):
         del kwargs["queue"]
         super(InstrumentedTestRunner, self).__init__(*args, **kwargs)
 
-    def run_single_test(self):
+    def _run_single_test(self, test_context):
         # write current memory usage to file before running the test
         pid = os.getpid()
         current_memory = _get_memory(pid)
         self.queue.put(current_memory)
 
-        data = super(InstrumentedTestRunner, self).run_single_test()
+        data = super(InstrumentedTestRunner, self)._run_single_test(test_context)
         return data
 
 


### PR DESCRIPTION
These methods will be used for preallocation of a subcluster before the run of a given test when running tests in parallel.