### PR TITLE
Adding a check for a test that does not use any cluster nodes 

### DIFF
--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -193,7 +193,7 @@ class TestResults(object):
         }
 
     def to_json(self):
-        if self.run_time_seconds == 0:
+        if self.run_time_seconds == 0 or sum([r.nodes_used * r.run_time_seconds for r in self]) == 0:
             # If things go horribly wrong, the test run may be effectively instantaneous
             # Let's handle this case gracefully, and avoid divide-by-zero
             cluster_utilization = 0


### PR DESCRIPTION
Adding a check for a test that does not use any cluster nodes to prevent a divide by zero error.