### PR TITLE
remoteaccount: add java_pids, kill_java_processes

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -371,6 +371,22 @@ class RemoteAccount(HttpMixin):
         for pid in pids:
             self.signal(pid, sig, allow_fail=allow_fail)
 
+    def java_pids(self, match):
+        cmd = """jcmd | grep """ + match + """ | awk '{print $1}'"""
+        return [int(pid) for pid in self.ssh_capture(cmd, allow_fail=True)]
+
+    def kill_java_processes(self, class_str, clean_shutdown=True, allow_fail=False):
+        cmd = """jcmd | grep """ + class_str + """ | awk '{print $1}'"""
+        pids = [pid for pid in self.ssh_capture(cmd, allow_fail=True)]
+
+        if clean_shutdown:
+            sig = signal.SIGTERM
+        else:
+            sig = signal.SIGKILL
+
+        for pid in pids:
+            self.signal(pid, sig, allow_fail=allow_fail)
+
     def copy_between(self, src, dest, dest_node):
         """Copy src to dest on dest_node
 

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -372,11 +372,24 @@ class RemoteAccount(HttpMixin):
             self.signal(pid, sig, allow_fail=allow_fail)
 
     def java_pids(self, match):
-        cmd = """jcmd | grep """ + match + """ | awk '{print $1}'"""
+        """
+        Get all the Java process IDs matching 'match'.
+
+        :param match:               The AWK expression to match
+        """
+        cmd = """jcmd | awk '/%s/ { print $1 }'""" % match
         return [int(pid) for pid in self.ssh_capture(cmd, allow_fail=True)]
 
-    def kill_java_processes(self, class_str, clean_shutdown=True, allow_fail=False):
-        cmd = """jcmd | grep """ + class_str + """ | awk '{print $1}'"""
+    def kill_java_processes(self, match, clean_shutdown=True, allow_fail=False):
+        """
+        Kill all the java processes matching 'match'.
+
+        :param match:               The AWK expression to match
+        :param clean_shutdown:      True if we should shut down cleanly with SIGTERM;
+                                    false if we should shut down with SIGKILL.
+        :param allow_fail:          True if we should throw exceptions if the ssh commands fail.
+        """
+        cmd = """jcmd | awk '/%s/ { print $1 }'""" % match
         pids = [pid for pid in self.ssh_capture(cmd, allow_fail=True)]
 
         if clean_shutdown:


### PR DESCRIPTION
Add java_pids, a function to find the process IDs of running java
processes based on a classname string.

Add kill_java_processes, a function to kill running java processes based
on their classname.

These functions are more precise than grepping for java and then
grepping for a further string in the process name.  That process can
catch many java processes besides the intended one.