### PR TITLE
Introduce ClusterSpec

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Ducktape contains tools for running system integration and performance tests. It
 
 .. toctree::
    install
+   test_clusters
    run_tests
    new_tests
    new_services

--- a/docs/new_services.rst
+++ b/docs/new_services.rst
@@ -22,7 +22,7 @@ Each service is implemented as a class and should at least implement the followi
 
 These may block to ensure services start or stop properly, but must *not* block for the full lifetime of the service. If you need to run a blocking process (e.g. run a process via SSH and iterate over its output), this should be done in a background thread. For services that exit after completing a fixed operation (e.g. produce N messages to topic foo), you should also implement ``wait``, which will usually just wait for background worker threads to exit. The ``Service`` base class provides a helper method ``run`` which wraps ``start``, ``wait``, and ``stop`` for tests that need to start a service and wait for it to finish. You can also provide additional helper methods for common test functionality. Normal services might provide a ``bounce`` method.
 
-Most of the code you'll write for a service will just be series of SSH commands and tests of output. You should request the number of nodes you'll need using the ``num_nodes`` or ``node_spec`` parameter to the Service base class's constructor. Then, in your Service's methods you'll have access to ``self.nodes`` to access the nodes allocated to your service. Each node has an associated :class:`~ducktape.cluster.remoteaccount.RemoteAccount` instance which lets you easily perform remote operations such as running commands via SSH or creating files. By default, these operations try to hide output (but provide it to you if you need to extract some subset of it) and *checks status codes for errors* so any operations that fail cause an obvious failure of the entire test.
+Most of the code you'll write for a service will just be series of SSH commands and tests of output. You should request the number of nodes you'll need using the ``num_nodes`` or ``cluster_spec`` parameter to the Service base class's constructor. Then, in your Service's methods you'll have access to ``self.nodes`` to access the nodes allocated to your service. Each node has an associated :class:`~ducktape.cluster.remoteaccount.RemoteAccount` instance which lets you easily perform remote operations such as running commands via SSH or creating files. By default, these operations try to hide output (but provide it to you if you need to extract some subset of it) and *checks status codes for errors* so any operations that fail cause an obvious failure of the entire test.
 
 .. _service-example-ref:
 
@@ -151,3 +151,4 @@ Suppose we named the file zookeeper.properties. The creation of the config file 
 
         prop_file = self.render('zookeeper.properties')
         node.account.create_file(self.CONFIG_FILE, prop_file)
+

--- a/docs/test_clusters.rst
+++ b/docs/test_clusters.rst
@@ -1,0 +1,22 @@
+.. _topics-test_clusters:
+
+===================
+Test Clusters
+===================
+
+Ducktape runs on a test cluster with several nodes.  Ducktape will take ownership of the nodes and handle starting, stopping, and running services on them.
+
+Many test environments are possible.  The nodes may be local nodes, running inside Docker.  Or they could be virtual machines running on a public cloud.
+
+Cluster Specifications
+======================
+
+A cluster specification-- also called a ClusterSpec-- describes a particular
+cluster configuration.  Currently the cluster specification can express the
+number of nodes of each operating system that are required.
+
+Cluster specifications give us a vocabulary to express what a particular
+service or test needs to run.  For example, a service might require a cluster
+with three Linux nodes and one Windows node.  We could express that with a
+ClusterSpec containing three Linux NodeSpec objects and one Windows NodeSpec
+object.

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import collections
-from .remoteaccount import RemoteAccount
 
 
 class ClusterNode(object):
@@ -23,6 +22,10 @@ class ClusterNode(object):
             setattr(self, k, v)
 
     @property
+    def name(self):
+        return self.account.host
+
+    @property
     def operating_system(self):
         return self.account.operating_system
 
@@ -30,22 +33,21 @@ class ClusterNode(object):
 class Cluster(object):
     """ Interface for a cluster -- a collection of nodes with login credentials.
     This interface doesn't define any mapping of roles/services to nodes. It only interacts with some underlying
-    system that can describe available resources and mediates reservations of those resources. This is intentionally
-    simple right now: the only "resource" right now is a generic VM and it is assumed everything is approximately
-    homogeneous.
+    system that can describe available resources and mediates reservations of those resources.
     """
 
     def __len__(self):
         """Size of this cluster object. I.e. number of 'nodes' in the cluster."""
-        raise NotImplementedError()
+        return self.available().size() + self.used().size()
 
-    def alloc(self, node_spec):
-        """Try to allocate the specified number of nodes, which will be reserved until they are freed by the caller."""
-        raise NotImplementedError()
+    def alloc(self, cluster_spec):
+        """
+        Allocate some nodes.
 
-    def request(self, num_nodes):
-        """Identical to alloc. Keeping for compatibility"""
-        return self.alloc(num_nodes)
+        :param cluster_spec:                    A ClusterSpec describing the nodes to be allocated.
+        :throws InsufficientResources:          If the nodes cannot be allocated.
+        """
+        raise NotImplementedError
 
     def free(self, nodes):
         """Free the given node or list of nodes"""
@@ -64,46 +66,23 @@ class Cluster(object):
     def __hash__(self):
         return hash(tuple(sorted(self.__dict__.items())))
 
-    def num_nodes_for_operating_system(self, operating_system):
-        return self.in_use_nodes_for_operating_system(operating_system) + \
-               self.num_available_nodes(operating_system=operating_system)
+    def num_available_nodes(self):
+        return self.available().size()
 
-    def num_available_nodes(self, operating_system=RemoteAccount.LINUX):
-        """Number of available nodes."""
-        return Cluster._node_count_helper(self._available_nodes, operating_system)
-
-    def in_use_nodes_for_operating_system(self, operating_system):
-        return Cluster._node_count_helper(self._in_use_nodes, operating_system)
-
-    @property
-    def node_spec(self):
-        node_spec = {}
-        for operating_system in RemoteAccount.SUPPORTED_OS_TYPES:
-            node_spec[operating_system] = self.num_nodes_for_operating_system(operating_system)
-        return node_spec
-
-    def test_capacity_comparison(self, test):
+    def available(self):
         """
-        Checks if the test can 'fit' into the cluster, using the test's node_spec.
-
-        A negative return value (int) means the test needs more capacity than is available in the cluster.
-        A return value of 0 means the cluster has exactly the right number of resources as the test needs.
-        A positive return value (int) means the cluster has more capacity than the test needs.
+        Return a ClusterSpec object describing the currently available nodes.
         """
-        num_available = 0
-        for (operating_system, node_count) in test.expected_node_spec.iteritems():
-            if node_count > self.num_nodes_for_operating_system(operating_system):
-                # return -1 immediately if the cluster doesn't have enough capacity for any operating system.
-                return -1
-            else:
-                num_available += self.num_nodes_for_operating_system(operating_system) - node_count
+        raise NotImplementedError
 
-        return num_available
+    def used(self):
+        """
+        Return a ClusterSpec object describing the currently in use nodes.
+        """
+        raise NotImplementedError
 
-    @staticmethod
-    def _node_count_helper(nodes, operating_system):
-        return len([node for node in nodes if node.operating_system == operating_system])
-
-    @staticmethod
-    def _next_available_node(nodes, operating_system):
-        return next(node for node in nodes if node.operating_system == operating_system)
+    def all(self):
+        """
+        Return a ClusterSpec object describing all nodes.
+        """
+        return self.available().clone().add(self.used())

--- a/ducktape/cluster/cluster_spec.py
+++ b/ducktape/cluster/cluster_spec.py
@@ -1,0 +1,119 @@
+# Copyright 2017 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import json
+
+from ducktape.cluster.node_container import NodeContainer
+
+LINUX = "linux"
+
+WINDOWS = "windows"
+
+SUPPORTED_OS_TYPES = [LINUX, WINDOWS]
+
+
+class NodeSpec(object):
+    """
+    The specification for a ducktape cluster node.
+
+    :param operating_system:    The operating system of the node.
+    """
+    def __init__(self, operating_system):
+        self.operating_system = operating_system
+        if self.operating_system not in SUPPORTED_OS_TYPES:
+            raise RuntimeError("Unsupported os type %s" % self.operating_system)
+
+    def __str__(self):
+        dict = {
+            "os": self.operating_system,
+        }
+        return json.dumps(dict, sort_keys=True)
+
+
+class ClusterSpec(object):
+    """
+    The specification for a ducktape cluster.
+    """
+
+    @staticmethod
+    def empty():
+        return ClusterSpec([])
+
+    @staticmethod
+    def simple_linux(num_nodes):
+        """
+        Create a ClusterSpec containing some simple Linux nodes.
+        """
+        """Convenience method to create a cluster of all linux nodes."""
+        node_specs = [NodeSpec(LINUX)] * num_nodes
+        return ClusterSpec(node_specs)
+
+    @staticmethod
+    def from_nodes(nodes):
+        """
+        Create a ClusterSpec describing a list of nodes.
+        """
+        node_specs = []
+        for node in nodes:
+            node_specs.append(NodeSpec(node.operating_system))
+        return ClusterSpec(node_specs)
+
+    def __init__(self, nodes=None):
+        """
+        Initialize the ClusterSpec.
+
+        :param nodes:           A collection of NodeSpecs, or None to create an empty cluster spec.
+        """
+        self.nodes = NodeContainer(nodes)
+
+    def __len__(self):
+        return self.size()
+
+    def __iter__(self):
+        return self.nodes.elements()
+
+    def size(self):
+        """Return the total size of this cluster spec, including all types of nodes."""
+        return self.nodes.size()
+
+    def add(self, other):
+        """
+        Add another ClusterSpec to this one.
+
+        :param node_spec:       The other cluster spec.  This will not be modified.
+        :return:                This ClusterSpec.
+        """
+        for node_spec in other.nodes:
+            self.nodes.add_node(node_spec)
+        return self
+
+    def clone(self):
+        """
+        Returns a deep copy of this object.
+        """
+        return ClusterSpec(self.nodes.clone())
+
+    def __str__(self):
+        node_spec_to_num = {}
+        for node_spec in self.nodes.elements():
+            node_spec_str = str(node_spec)
+            node_spec_to_num[node_spec_str] = node_spec_to_num.get(node_spec_str, 0) + 1
+        rval = []
+        for node_spec_str in sorted(node_spec_to_num.keys()):
+            node_spec = json.loads(node_spec_str)
+            node_spec["num_nodes"] = node_spec_to_num[node_spec_str]
+            rval.append(node_spec)
+        return json.dumps(rval, sort_keys=True)

--- a/ducktape/cluster/cluster_spec.py
+++ b/ducktape/cluster/cluster_spec.py
@@ -31,7 +31,7 @@ class NodeSpec(object):
 
     :param operating_system:    The operating system of the node.
     """
-    def __init__(self, operating_system):
+    def __init__(self, operating_system=LINUX):
         self.operating_system = operating_system
         if self.operating_system not in SUPPORTED_OS_TYPES:
             raise RuntimeError("Unsupported os type %s" % self.operating_system)
@@ -57,7 +57,6 @@ class ClusterSpec(object):
         """
         Create a ClusterSpec containing some simple Linux nodes.
         """
-        """Convenience method to create a cluster of all linux nodes."""
         node_specs = [NodeSpec(LINUX)] * num_nodes
         return ClusterSpec(node_specs)
 
@@ -66,10 +65,7 @@ class ClusterSpec(object):
         """
         Create a ClusterSpec describing a list of nodes.
         """
-        node_specs = []
-        for node in nodes:
-            node_specs.append(NodeSpec(node.operating_system))
-        return ClusterSpec(node_specs)
+        return ClusterSpec(ClusterSpec([NodeSpec(node.operating_system) for node in nodes]))
 
     def __init__(self, nodes=None):
         """

--- a/ducktape/cluster/linux_remoteaccount.py
+++ b/ducktape/cluster/linux_remoteaccount.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ducktape.cluster.cluster_spec import LINUX
 from ducktape.cluster.remoteaccount import RemoteAccount
 
 
@@ -22,7 +23,7 @@ class LinuxRemoteAccount(RemoteAccount):
                                                  logger=logger)
         self._ssh_client = None
         self._sftp_client = None
-        self.os = RemoteAccount.LINUX
+        self.os = LINUX
 
     @property
     def local(self):

--- a/ducktape/cluster/node_container.py
+++ b/ducktape/cluster/node_container.py
@@ -1,0 +1,160 @@
+# Copyright 2017 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class NodeNotPresentError(Exception):
+    pass
+
+
+class InsufficientResourcesError(Exception):
+    pass
+
+
+class NodeContainer(object):
+    def __init__(self, nodes=None):
+        """
+        Create a NodeContainer with the given nodes.
+
+        Node objects should implement at least an operating_system property.
+
+        :param nodes:           A collection of node objects to add, or None to add nothing.
+        """
+        self.os_to_nodes = {}
+        if nodes is not None:
+            for node in nodes:
+                self.os_to_nodes.setdefault(node.operating_system, []).append(node)
+
+    def size(self):
+        """
+        Returns the total number of nodes in the container.
+        """
+        return sum([len(val) for val in self.os_to_nodes.values()])
+
+    def __len__(self):
+        return self.size()
+
+    def __iter__(self):
+        return self.elements()
+
+    def elements(self, operating_system=None):
+        """
+        Yield the elements in this container.
+
+        :param operating_system:    If this is non-None, we will iterate only over elements
+                                    which have this operating system.
+        """
+        if operating_system is None:
+            for node_list in self.os_to_nodes.values():
+                for node in node_list:
+                    yield node
+        else:
+            for node in self.os_to_nodes.get(operating_system, []):
+                yield node
+
+    def add_node(self, node):
+        """
+        Add a node to this collection.
+
+        :param node:                        The node to add.
+        """
+        self.os_to_nodes.setdefault(node.operating_system, []).append(node)
+
+    def add_nodes(self, nodes):
+        """
+        Add a collection of nodes to this collection.
+
+        :param nodes:                       The nodes to add.
+        """
+        for node in nodes:
+            self.add_node(node)
+
+    def remove_node(self, node):
+        """
+        Removes a node from this collection.
+
+        :param node:                        The node to remove.
+        :returns:                           The node which has been removed.
+        :throws NodeNotPresentError:        If the node is not in the collection.
+        """
+        try:
+            return self.os_to_nodes.get(node.operating_system, []).remove(node)
+        except ValueError:
+            raise NodeNotPresentError
+
+    def remove_nodes(self, nodes):
+        """
+        Remove a collection of nodes from this collection.
+
+        :param nodes:                       The nodes to remove.
+        """
+        for node in nodes:
+            self.remove_node(node)
+
+    def remove_spec(self, cluster_spec):
+        """
+        Remove nodes matching a ClusterSpec from this NodeContainer.
+
+        :param cluster_spec:                    The cluster spec.  This will not be modified.
+        :returns:                               A list of the nodes that were removed.
+        :throws InsufficientResourcesError:     If there are not enough nodes in the NodeContainer.
+                                                Nothing will be removed unless enough are available.
+        """
+        msg = self.attempt_remove_spec(cluster_spec)
+        if len(msg) > 0:
+            raise InsufficientResourcesError("Not enough nodes available to allocate. " + msg)
+        removed = []
+        for os, node_specs in cluster_spec.nodes.os_to_nodes.iteritems():
+            num_nodes = len(node_specs)
+            avail_nodes = self.os_to_nodes.get(os, [])
+            for i in range(0, num_nodes):
+                removed.append(avail_nodes.pop(0))
+        return removed
+
+    def can_remove_spec(self, cluster_spec):
+        """
+        Determine if we can remove nodes matching a ClusterSpec from this NodeContainer.
+        This container will not be modified.
+
+        :param cluster_spec:                    The cluster spec.  This will not be modified.
+        :returns:                               True if we could remove the nodes; false otherwise
+        """
+        msg = self.attempt_remove_spec(cluster_spec)
+        return len(msg) == 0
+
+    def attempt_remove_spec(self, cluster_spec):
+        """
+        Attempt to remove a cluster_spec from this node container.
+
+        :param cluster_spec:                    The cluster spec.  This will not be modified.
+        :returns:                               An empty string if we can remove the nodes;
+                                                an error string otherwise.
+        """
+        msg = ""
+        for os, node_specs in cluster_spec.nodes.os_to_nodes.iteritems():
+            num_nodes = len(node_specs)
+            avail_nodes = len(self.os_to_nodes.get(os, []))
+            if avail_nodes < num_nodes:
+                msg = msg + "%s nodes requested: %d. %s nodes available: %d" % \
+                            (os, num_nodes, os, avail_nodes)
+        return msg
+
+    def clone(self):
+        """
+        Returns a deep copy of this object.
+        """
+        container = NodeContainer()
+        for operating_system, nodes in self.os_to_nodes.iteritems():
+            for node in nodes:
+                container.os_to_nodes.setdefault(operating_system, []).append(node)
+        return container

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -120,10 +120,6 @@ class RemoteAccount(HttpMixin):
     Each operating system has its own RemoteAccount implementation.
     """
 
-    LINUX = "linux"
-    WINDOWS = "windows"
-    SUPPORTED_OS_TYPES = [LINUX, WINDOWS]
-
     def __init__(self, ssh_config, externally_routable_ip=None, logger=None):
         # Instance of RemoteAccountSSHConfig - use this instead of a dict, because we need the entire object to
         # be hashable

--- a/ducktape/cluster/vagrant.py
+++ b/ducktape/cluster/vagrant.py
@@ -60,14 +60,14 @@ class VagrantCluster(JsonCluster):
                     "ssh_config": node_account.ssh_config,
                     "externally_routable_ip": node_account.externally_routable_ip
                 }
-                for node_account in self._available_nodes
+                for node_account in self._available_accounts
             ]
             cluster_json["nodes"] = nodes
             with open(cluster_file, 'w+') as fd:
                 json.dump(cluster_json, fd, cls=DucktapeJSONEncoder, indent=2, separators=(',', ': '), sort_keys=True)
 
         # Release any ssh clients used in querying the nodes for metadata
-        for node_account in self._available_nodes:
+        for node_account in self._available_accounts:
             node_account.close()
 
     def _get_nodes_from_vagrant(self):

--- a/ducktape/cluster/windows_remoteaccount.py
+++ b/ducktape/cluster/windows_remoteaccount.py
@@ -22,6 +22,8 @@ from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_v1_5
 
 from botocore.exceptions import ClientError
+
+from ducktape.cluster.cluster_spec import WINDOWS
 from ducktape.cluster.remoteaccount import RemoteAccount, RemoteCommandError
 
 
@@ -38,7 +40,7 @@ class WindowsRemoteAccount(RemoteAccount):
     def __init__(self, ssh_config, externally_routable_ip=None, logger=None):
         super(WindowsRemoteAccount, self).__init__(ssh_config, externally_routable_ip=externally_routable_ip,
                                                    logger=logger)
-        self.os = RemoteAccount.WINDOWS
+        self.os = WINDOWS
         self._winrm_client = None
 
     @property

--- a/ducktape/mark/resource.py
+++ b/ducktape/mark/resource.py
@@ -46,7 +46,7 @@ def cluster(**kwargs):
     :Keywords used by ducktape:
 
         - ``num_nodes`` provide hint about how many nodes the test will consume
-        - ``node_spec`` provide hint about how many nodes for each operating system the test will consume
+        - ``cluster_spec`` provide hint about how many nodes of each type the test will consume
 
 
     Example::
@@ -56,8 +56,8 @@ def cluster(**kwargs):
         def the_test(...):
             ...
 
-        # basic usage with node_spec
-        @cluster(node_spec={ducktape.cluster.remoteaccount.RemoteAccount.LINUX: 10})
+        # basic usage with cluster_spec
+        @cluster(cluster_spec=ClusterSpec.simple_linux(10))
         def the_test(...):
             ...
 

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -15,6 +15,8 @@
 
 from collections import OrderedDict
 
+from ducktape.cluster.cluster_spec import ClusterSpec
+
 
 class ServiceRegistry(object):
 
@@ -83,13 +85,12 @@ class ServiceRegistry(object):
         if keyboard_interrupt is not None:
             raise keyboard_interrupt
 
-    def num_nodes(self):
-        """Returns a dict where the key is the operating system and the value is the number of nodes for said OS."""
-        nodes_per_os = {}
-        for service in self:
-            for (operating_system, node_count) in service.node_spec.iteritems():
-                if operating_system in nodes_per_os:
-                    nodes_per_os[operating_system] += node_count
-                else:
-                    nodes_per_os[operating_system] = node_count
-        return nodes_per_os
+    def min_cluster_spec(self):
+        """
+        Returns the minimum cluster specification that would be required to run all the currently
+        extant services.
+        """
+        cluster_spec = ClusterSpec()
+        for service in self._services.values():
+            cluster_spec.add(service.cluster_spec)
+        return cluster_spec

--- a/ducktape/tests/scheduler.py
+++ b/ducktape/tests/scheduler.py
@@ -25,10 +25,14 @@ class TestScheduler(object):
 
         # Track tests which would never be offered up by the scheduling algorithm due to insufficient
         # cluster resources
-        self.unschedulable = [tc for tc in test_contexts if cluster.test_capacity_comparison(tc) < 0]
-
-        # these can be scheduled
-        self._test_context_list = [tc for tc in test_contexts if cluster.test_capacity_comparison(tc) >= 0]
+        self._test_context_list = []
+        self.unschedulable = []
+        available = cluster.available()
+        for test_context in test_contexts:
+            if available.nodes.can_remove_spec(test_context.expected_cluster_spec):
+                self._test_context_list.append(test_context)
+            else:
+                self.unschedulable.append(test_context)
         self._sort_test_context_list()
 
     def __len__(self):
@@ -55,7 +59,7 @@ class TestScheduler(object):
             If scheduler is empty, or no test can currently be scheduled, return None.
         """
         for tc in self._test_context_list:
-            if self.cluster.test_capacity_comparison(tc) >= 0:
+            if self.cluster.available().nodes.can_remove_spec(tc.expected_cluster_spec):
                 return tc
 
         return None

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.services.service import Service
 from ducktape.tests.test import Test
 from ducktape.errors import TimeoutError
@@ -382,6 +382,14 @@ class CopyDirectTest(Test):
         make_dir_structure(self.remote_scratch_dir, DIR_STRUCTURE, node=self.src_node)
         self.src_node.account.copy_between(self.remote_scratch_dir, self.remote_scratch_dir, self.dest_node)
         verify_dir_structure(os.path.join(self.remote_scratch_dir, "scratch"), DIR_STRUCTURE, node=self.dest_node)
+
+
+class TestClusterSpec(Test):
+    @cluster(cluster_spec=ClusterSpec.simple_linux(2))
+    def test_create_two_node_service(self):
+        self.service = GenericService(self.test_context, 2)
+        for node in self.service.nodes:
+            node.account.ssh("echo hi")
 
 
 class RemoteAccountTest(Test):

--- a/tests/cluster/check_cluster_spec.py
+++ b/tests/cluster/check_cluster_spec.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Confluent Inc.
+# Copyright 2015 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,25 +13,16 @@
 # limitations under the License.
 
 from ducktape.cluster.cluster_spec import ClusterSpec
-from ducktape.tests.test import Test
-from ducktape.mark import ignore, parametrize
 
 
-class TestThingy(Test):
-    """Fake ducktape test class"""
+class CheckClusterSpec(object):
+    def check_cluster_spec_sizes(self):
+        simple_linux_2 = ClusterSpec.simple_linux(2)
+        assert 2 == len(simple_linux_2)
+        assert 0 == len(ClusterSpec.empty())
 
-    def min_cluster_spec(self):
-        """ This test uses many nodes, wow!"""
-        return ClusterSpec.simple_linux(1000)
-
-    def test_pi(self):
-        return {"data": 3.14159}
-
-    @ignore
-    def test_ignore1(self):
-        pass
-
-    @ignore(x=5)
-    @parametrize(x=5)
-    def test_ignore2(self, x=2):
-        pass
+    def check_to_string(self):
+        empty = ClusterSpec.empty()
+        assert "[]" == str(empty)
+        simple_linux_5 = ClusterSpec.simple_linux(5)
+        assert '[{"num_nodes": 5, "os": "linux"}]' == str(simple_linux_5)

--- a/tests/cluster/check_json.py
+++ b/tests/cluster/check_json.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ducktape.cluster.json import JsonCluster
+from ducktape.cluster.node_container import InsufficientResourcesError
 from ducktape.services.service import Service
 import pickle
 import pytest
@@ -70,12 +71,12 @@ class CheckJsonCluster(object):
         assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 3)
 
-        nodes = cluster.alloc(Service.setup_node_spec(num_nodes=1))
+        nodes = cluster.alloc(Service.setup_cluster_spec(num_nodes=1))
         nodes_hostnames = self.cluster_hostnames(nodes)
         assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 2)
 
-        nodes2 = cluster.alloc(Service.setup_node_spec(num_nodes=2))
+        nodes2 = cluster.alloc(Service.setup_cluster_spec(num_nodes=2))
         nodes2_hostnames = self.cluster_hostnames(nodes2)
         assert len(cluster) == 3
         assert(cluster.num_available_nodes() == 0)
@@ -94,7 +95,7 @@ class CheckJsonCluster(object):
         node = JsonCluster(
             {
                 "nodes": [
-                    {"ssh_config": {"host": "hostname"}}]}).alloc(Service.setup_node_spec(num_nodes=1))[0]
+                    {"ssh_config": {"host": "hostname"}}]}).alloc(Service.setup_cluster_spec(num_nodes=1))[0]
 
         assert node.account.hostname == "hostname"
         assert node.account.user is None
@@ -107,7 +108,7 @@ class CheckJsonCluster(object):
         }
         node = JsonCluster({"nodes": [{"hostname": "hostname",
                                        "user": "user",
-                                       "ssh_config": ssh_config}]}).alloc(Service.setup_node_spec(num_nodes=1))[0]
+                                       "ssh_config": ssh_config}]}).alloc(Service.setup_cluster_spec(num_nodes=1))[0]
 
         assert node.account.hostname == "hostname"
         assert node.account.user == "user"
@@ -120,5 +121,5 @@ class CheckJsonCluster(object):
 
     def check_exhausts_supply(self):
         cluster = JsonCluster(self.single_node_cluster_json)
-        with pytest.raises(RuntimeError):
-            cluster.alloc(Service.setup_node_spec(num_nodes=2))
+        with pytest.raises(InsufficientResourcesError):
+            cluster.alloc(Service.setup_cluster_spec(num_nodes=2))

--- a/tests/cluster/check_localhost.py
+++ b/tests/cluster/check_localhost.py
@@ -34,7 +34,7 @@ class CheckLocalhostCluster(object):
         initial_size = len(self.cluster)
 
         # Should be able to allocate arbitrarily many nodes
-        nodes = self.cluster.alloc(Service.setup_node_spec(num_nodes=100))
+        nodes = self.cluster.alloc(Service.setup_cluster_spec(num_nodes=100))
         assert(len(nodes) == 100)
         for i, node in enumerate(nodes):
             assert node.account.hostname == 'localhost%d' % i

--- a/tests/cluster/check_node_container.py
+++ b/tests/cluster/check_node_container.py
@@ -1,0 +1,53 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.cluster.node_container import NodeContainer, NodeNotPresentError
+import pytest
+
+from tests.ducktape_mock import MockAccount
+
+
+class CheckNodeContainer(object):
+    def check_sizes(self):
+        empty = NodeContainer()
+        assert 0 == empty.size()
+        assert 0 == len(empty)
+        nodes = [ClusterNode(MockAccount())]
+        container = NodeContainer(nodes)
+        assert 1 == container.size()
+        assert 1 == len(container)
+
+    def check_add_and_remove(self):
+        nodes = [ClusterNode(MockAccount()),
+                 ClusterNode(MockAccount()),
+                 ClusterNode(MockAccount()),
+                 ClusterNode(MockAccount()),
+                 ClusterNode(MockAccount())]
+        container = NodeContainer([])
+        assert 0 == len(container)
+        container.add_node(nodes[0])
+        container.add_node(nodes[1])
+        container.add_node(nodes[2])
+        container2 = container.clone()
+        i = 0
+        for node in container:
+            assert nodes[i] == node
+            i += 1
+        assert 3 == len(container)
+        container.remove_node(nodes[0])
+        with pytest.raises(NodeNotPresentError):
+            container.remove_node(nodes[0])
+        assert 2 == len(container)
+        assert 3 == len(container2)

--- a/tests/cluster/check_vagrant.py
+++ b/tests/cluster/check_vagrant.py
@@ -78,7 +78,7 @@ class CheckVagrantCluster(object):
         cluster = VagrantCluster()
         assert len(cluster) == 2
         assert cluster.num_available_nodes() == 2
-        node1, node2 = cluster.alloc(Service.setup_node_spec(num_nodes=2))
+        node1, node2 = cluster.alloc(Service.setup_cluster_spec(num_nodes=2))
 
         assert node1.account.hostname == "worker1"
         assert node1.account.user == "vagrant"
@@ -110,7 +110,7 @@ class CheckVagrantCluster(object):
                     "port": node_account.ssh_config.port
                 }
             }
-            for node_account in cluster._available_nodes
+            for node_account in cluster._available_accounts
         ]
 
         cluster_json_expected["nodes"] = nodes
@@ -163,7 +163,7 @@ class CheckVagrantCluster(object):
 
         assert len(cluster) == 2
         assert cluster.num_available_nodes() == 2
-        node2, node3 = cluster.alloc(Service.setup_node_spec(num_nodes=2))
+        node2, node3 = cluster.alloc(Service.setup_cluster_spec(num_nodes=2))
 
         assert node3.account.hostname == "worker2"
         assert node3.account.user == "vagrant"

--- a/tests/scheduler/check_scheduler.py
+++ b/tests/scheduler/check_scheduler.py
@@ -16,21 +16,21 @@
 import collections
 import pytest
 
+from ducktape.cluster.cluster_spec import ClusterSpec
 from tests.ducktape_mock import FakeCluster
 from ducktape.tests.scheduler import TestScheduler
 from ducktape.services.service import Service
-from ducktape.cluster.remoteaccount import RemoteAccount
 
-FakeContext = collections.namedtuple('FakeContext', ['test_id', 'expected_num_nodes', 'expected_node_spec'])
+FakeContext = collections.namedtuple('FakeContext', ['test_id', 'expected_num_nodes', 'expected_cluster_spec'])
 
 
 class CheckScheduler(object):
     def setup_method(self, _):
         self.cluster = FakeCluster(100)
         self.tc_list = [
-            FakeContext(0, expected_num_nodes=10, expected_node_spec={RemoteAccount.LINUX: 10}),
-            FakeContext(1, expected_num_nodes=50, expected_node_spec={RemoteAccount.LINUX: 50}),
-            FakeContext(2, expected_num_nodes=100, expected_node_spec={RemoteAccount.LINUX: 100}),
+            FakeContext(0, expected_num_nodes=10, expected_cluster_spec=ClusterSpec.simple_linux(10)),
+            FakeContext(1, expected_num_nodes=50, expected_cluster_spec=ClusterSpec.simple_linux(50)),
+            FakeContext(2, expected_num_nodes=100, expected_cluster_spec=ClusterSpec.simple_linux(100)),
         ]
 
     def check_empty(self):
@@ -50,7 +50,7 @@ class CheckScheduler(object):
         assert scheduler.peek() is not None
 
         # alloc all cluster nodes so none are available
-        self.cluster.alloc(Service.setup_node_spec(num_nodes=len(self.cluster)))
+        self.cluster.alloc(Service.setup_cluster_spec(num_nodes=len(self.cluster)))
         assert self.cluster.num_available_nodes() == 0
 
         # peeking etc should not yield an object
@@ -81,7 +81,7 @@ class CheckScheduler(object):
         scheduler = TestScheduler(self.tc_list, self.cluster)
 
         # allocate 60 nodes; only test_id 0 should be available
-        nodes = self.cluster.alloc(Service.setup_node_spec(num_nodes=60))
+        nodes = self.cluster.alloc(Service.setup_cluster_spec(num_nodes=60))
         assert self.cluster.num_available_nodes() == 40
         t = scheduler.next()
         assert t.test_id == 0


### PR DESCRIPTION
Introduce the ClusterSpec object to represent a specification for a cluster.
Currently, ClusterSpec can express that a cluster must have a certain number of
nodes of various operating systems.  In the future, we may add support for
tagging nodes.

Cluster: remove OS-specific methods and consolidate interfaces into three
methods which return ClusterSpec objects: available(), used(), and all().
Remove deprecated "request" method, since it is not being used.
The Cluster#alloc method now takes a cluster spec, not an int or a map.

JsonCluster: rename _available_nodes to _available_accounts, since this
collection stores account objects rather than node objects.

Service: add a num_nodes property for tests which expect it.

Test: add a new min_cluster_spec method.  Provide a better compatibility path
for Test subclasses which currently override min_cluster_size.

TestContext#close: do not throw an exception on double close-- this makes unit
test failures hard to read.

Rename the ClusterSlot class to ClusterNode.

Add a NodeContainer class which can efficiently store nodes in a per-OS
fashion.  The class also has utility methods for removing nodes matching a cluster
spec.  This simplifies writing Cluster subclasses