### PR TITLE
TestContext should be robust against multiple close calls

### DIFF
--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -451,12 +451,12 @@ class TestContext(object):
 
     def close(self):
         """Release resources, etc."""
-        for service in self.services:
-            service.close()
-
-        # Remove reference to services. This is important to prevent potential memory leaks if users write services
-        # which themselves have references to large memory-intensive objects
-        del self.services
+        if hasattr(self, "services"):
+            for service in self.services:
+                service.close()
+            # Remove reference to services. This is important to prevent potential memory leaks if users write services
+            # which themselves have references to large memory-intensive objects
+            del self.services
 
         # Remove local scratch directory
         if self._local_scratch_dir and os.path.exists(self._local_scratch_dir):

--- a/tests/tests/check_test.py
+++ b/tests/tests/check_test.py
@@ -39,6 +39,14 @@ class DummyTestNoDescription(Test):
         pass
 
 
+class CheckLifecycle(object):
+    def check_test_context_double_close(self):
+        context = TestContext(session_context=ducktape_mock.session_context(),
+                              cls=DummyTest, function=DummyTest.test_function_description)
+        context.close()
+        context.close()
+
+
 class CheckEscapePathname(object):
 
     def check_illegal_path(self):

--- a/tests/tests/check_test.py
+++ b/tests/tests/check_test.py
@@ -45,6 +45,7 @@ class CheckLifecycle(object):
                               cls=DummyTest, function=DummyTest.test_function_description)
         context.close()
         context.close()
+        assert not hasattr(context, "services")
 
 
 class CheckEscapePathname(object):


### PR DESCRIPTION
TestContext should be robust against multiple close calls.  This helps
when debugging unit test issues that result in close being called more
than once.