### PR TITLE
Use "node" consistently instead of "slot"

### DIFF
--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -16,7 +16,7 @@ import collections
 from .remoteaccount import RemoteAccount
 
 
-class ClusterSlot(object):
+class ClusterNode(object):
     def __init__(self, account, **kwargs):
         self.account = account
         for k, v in kwargs.items():

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 
 from ducktape.command_line.defaults import ConsoleDefaults
-from .cluster import Cluster, ClusterSlot
+from .cluster import Cluster, ClusterNode
 from .remoteaccount import RemoteAccount
 from ducktape.cluster.linux_remoteaccount import LinuxRemoteAccount
 from ducktape.cluster.windows_remoteaccount import WindowsRemoteAccount
@@ -134,18 +134,18 @@ class JsonCluster(Cluster):
             for i in range(num_nodes):
                 node = Cluster._next_available_node(self._available_nodes, operating_system)
                 self._available_nodes.remove(node)
-                cluster_slot = ClusterSlot(node, slot_id=self._id_supplier)
-                result.append(cluster_slot)
+                cluster_node = ClusterNode(node, node_id=self._id_supplier)
+                result.append(cluster_node)
                 self._in_use_nodes.add(node)
                 self._id_supplier += 1
 
         return result
 
-    def free_single(self, slot):
-        assert(slot.account in self._in_use_nodes)
-        slot.account.close()
-        self._in_use_nodes.remove(slot.account)
-        self._available_nodes.append(slot.account)
+    def free_single(self, node):
+        assert(node.account in self._in_use_nodes)
+        node.account.close()
+        self._in_use_nodes.remove(node.account)
+        self._available_nodes.append(node.account)
 
     def _externally_routable_ip(self, account):
         return None

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .cluster import Cluster, ClusterSlot
+from .cluster import Cluster, ClusterNode
 from .linux_remoteaccount import LinuxRemoteAccount
 from .remoteaccount import RemoteAccountSSHConfig
 from .remoteaccount import RemoteAccount
@@ -48,14 +48,14 @@ class LocalhostCluster(Cluster):
                 "localhost%d" % self._id_supplier,
                 hostname="localhost",
                 port=22)
-            allocated_nodes.append(ClusterSlot(LinuxRemoteAccount(ssh_config), slot_id=self._id_supplier))
+            allocated_nodes.append(ClusterNode(LinuxRemoteAccount(ssh_config), node_id=self._id_supplier))
             self._id_supplier += 1
         return allocated_nodes
 
     def num_available_nodes(self, operating_system=RemoteAccount.LINUX):
         return self._available
 
-    def free_single(self, slot):
+    def free_single(self, node):
         assert self._available + 1 <= self._size
-        slot.account.close()
+        node.account.close()
         self._available += 1

--- a/tests/cluster/check_localhost.py
+++ b/tests/cluster/check_localhost.py
@@ -34,18 +34,18 @@ class CheckLocalhostCluster(object):
         initial_size = len(self.cluster)
 
         # Should be able to allocate arbitrarily many nodes
-        slots = self.cluster.alloc(Service.setup_node_spec(num_nodes=100))
-        assert(len(slots) == 100)
-        for i, slot in enumerate(slots):
-            assert slot.account.hostname == 'localhost%d' % i
-            assert slot.account.ssh_hostname == 'localhost'
-            assert slot.account.ssh_config.hostname == 'localhost'
-            assert slot.account.ssh_config.port == 22
-            assert slot.account.user is None
+        nodes = self.cluster.alloc(Service.setup_node_spec(num_nodes=100))
+        assert(len(nodes) == 100)
+        for i, node in enumerate(nodes):
+            assert node.account.hostname == 'localhost%d' % i
+            assert node.account.ssh_hostname == 'localhost'
+            assert node.account.ssh_config.hostname == 'localhost'
+            assert node.account.ssh_config.port == 22
+            assert node.account.user is None
 
         assert(self.cluster.num_available_nodes() == (available - 100))
         assert len(self.cluster) == initial_size  # This shouldn't change
 
-        self.cluster.free(slots)
+        self.cluster.free(nodes)
 
         assert(self.cluster.num_available_nodes() == available)

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -29,7 +29,7 @@ def mock_cluster():
     return MagicMock()
 
 
-class FakeClusterSlot(object):
+class FakeClusterNode(object):
     @property
     def operating_system(self):
         return RemoteAccount.LINUX
@@ -47,17 +47,17 @@ class FakeCluster(Cluster):
         return self._num_nodes
 
     def alloc(self, node_spec):
-        """Request the specified number of slots, which will be reserved until they are freed by the caller."""
+        """Request the specified number of nodes, which will be reserved until they are freed by the caller."""
         # assume Linux.
         linux_node_count = node_spec[RemoteAccount.LINUX]
         self._available_nodes -= linux_node_count
-        return [FakeClusterSlot() for _ in range(linux_node_count)]
+        return [FakeClusterNode() for _ in range(linux_node_count)]
 
     def num_available_nodes(self, operating_system=RemoteAccount.LINUX):
         return self._available_nodes
 
-    def free(self, slots):
-        self._available_nodes += len(slots)
+    def free(self, nodes):
+        self._available_nodes += len(nodes)
 
     def free_single(self, _):
         self._available_nodes += 1

--- a/tests/scheduler/check_scheduler.py
+++ b/tests/scheduler/check_scheduler.py
@@ -81,7 +81,7 @@ class CheckScheduler(object):
         scheduler = TestScheduler(self.tc_list, self.cluster)
 
         # allocate 60 nodes; only test_id 0 should be available
-        slots = self.cluster.alloc(Service.setup_node_spec(num_nodes=60))
+        nodes = self.cluster.alloc(Service.setup_node_spec(num_nodes=60))
         assert self.cluster.num_available_nodes() == 40
         t = scheduler.next()
         assert t.test_id == 0
@@ -89,9 +89,9 @@ class CheckScheduler(object):
 
         # return 10 nodes, so 50 are available in the cluster
         # next test from the scheduler should be test id 1
-        return_slots = slots[: 10]
-        keep_slots = slots[10:]
-        self.cluster.free(return_slots)
+        return_nodes = nodes[: 10]
+        keep_nodes = nodes[10:]
+        self.cluster.free(return_nodes)
         assert self.cluster.num_available_nodes() == 50
         t = scheduler.next()
         assert t.test_id == 1
@@ -99,8 +99,8 @@ class CheckScheduler(object):
 
         # return remaining nodes, so cluster is fully available
         # next test from scheduler should be test id 2
-        return_slots = keep_slots
-        self.cluster.free(return_slots)
+        return_nodes = keep_nodes
+        self.cluster.free(return_nodes)
         assert self.cluster.num_available_nodes() == len(self.cluster)
         t = scheduler.next()
         assert t.test_id == 2


### PR DESCRIPTION
We should refer to cluster members as "nodes" consistently.