### PR TITLE
Allow wait_until err_msg to be generated by callable instead of fixed string

### DIFF
--- a/ducktape/utils/util.py
+++ b/ducktape/utils/util.py
@@ -22,7 +22,12 @@ import time
 def wait_until(condition, timeout_sec, backoff_sec=.1, err_msg=""):
     """Block until condition evaluates as true or timeout expires, whichever comes first.
 
-    return silently if condition becomes true within the timeout window, otherwise raise Exception with the given
+    :param condition: callable that returns True if the condition is met, False otherwise
+    :param timeout_sec: number of seconds to check the condition for before failing
+    :param backoff_sec: number of seconds to back off between each failure to meet the condition before checking again
+    :param err_msg: a string or callable returning a string that will be included as the exception message if the
+                    condition is not met
+    :return: silently if condition becomes true within the timeout window, otherwise raise Exception with the given
     error message.
     """
     start = time.time()
@@ -33,7 +38,7 @@ def wait_until(condition, timeout_sec, backoff_sec=.1, err_msg=""):
         else:
             time.sleep(backoff_sec)
 
-    raise TimeoutError(err_msg)
+    raise TimeoutError(err_msg() if callable(err_msg) else err_msg)
 
 
 def package_is_installed(package_name):

--- a/tests/utils/check_util.py
+++ b/tests/utils/check_util.py
@@ -34,3 +34,13 @@ class CheckUtils(object):
             raise Exception("This should have timed out")
         except Exception as e:
             assert e.message == "Hello world"
+
+    def check_wait_until_timeout_callable_msg(self):
+        """Check that timeout throws exception and the error message is generated via a callable"""
+        start = time.time()
+
+        try:
+            wait_until(lambda: time.time() > start + 5, timeout_sec=.5, backoff_sec=.1, err_msg=lambda: "Hello world")
+            raise Exception("This should have timed out")
+        except Exception as e:
+            assert e.message == "Hello world"


### PR DESCRIPTION
This allows you to generate the error message dynamically, which is useful in most cases where you want to include information about the final state of whatever you were waiting on. This isn't perfect since the state could change between the last failure and generating the error message, but in most cases this works fine, doesn't require logging every check made, and makes error messages much more useful in debugging.

There would probably be better variants like `wait_until_equals` that would allow for automatic reporting of the last values checked, but this is a reasonable, backwards compatible compromise in the meantime.