### PR TITLE
SSH command failure will either raise exception or log error

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -247,8 +247,12 @@ class RemoteAccount(HttpMixin):
         stdout.read()
         exit_status = stdout.channel.recv_exit_status()
         try:
-            if not allow_fail and exit_status != 0:
-                raise RemoteCommandError(self, cmd, exit_status, stderr.read())
+            if exit_status != 0:
+                if not allow_fail:
+                    raise RemoteCommandError(self, cmd, exit_status, stderr.read())
+                else:
+                    msg = "Running ssh command exited with status %d and message '%s': %s" % (exit_status, stderr.read(), cmd)
+                    self._log(logging.DEBUG, msg)
         finally:
             stdin.close()
             stdout.close()
@@ -296,8 +300,12 @@ class RemoteAccount(HttpMixin):
                     yield callback(line)
             try:
                 exit_status = stdout.channel.recv_exit_status()
-                if not allow_fail and exit_status != 0:
-                    raise RemoteCommandError(self, cmd, exit_status, stderr.read())
+                if exit_status != 0:
+                    if not allow_fail:
+                        raise RemoteCommandError(self, cmd, exit_status, stderr.read())
+                    else:
+                        msg = "Running ssh command exited with status %d and message '%s': %s" % (exit_status, stderr.read(), cmd)
+                        self._log(logging.DEBUG, msg)
             finally:
                 stdin.close()
                 stdout.close()
@@ -334,8 +342,12 @@ class RemoteAccount(HttpMixin):
         try:
             stdoutdata = stdout.read()
             exit_status = stdin.channel.recv_exit_status()
-            if not allow_fail and exit_status != 0:
-                raise RemoteCommandError(self, cmd, exit_status, stderr.read())
+            if exit_status != 0:
+                if not allow_fail:
+                    raise RemoteCommandError(self, cmd, exit_status, stderr.read())
+                else:
+                    msg = "Running ssh command exited with status %d and message '%s': %s" % (exit_status, stderr.read(), cmd)
+                    self._log(logging.DEBUG, msg)
         finally:
             stdin.close()
             stdout.close()

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -251,8 +251,8 @@ class RemoteAccount(HttpMixin):
                 if not allow_fail:
                     raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                 else:
-                    msg = "Running ssh command exited with status %d and message '%s': %s" % (exit_status, stderr.read(), cmd)
-                    self._log(logging.DEBUG, msg)
+                    self._log(logging.DEBUG, "Running ssh command exited with status %d and message '%s': %s" % \
+                        (exit_status, stderr.read(), cmd)
         finally:
             stdin.close()
             stdout.close()
@@ -304,8 +304,8 @@ class RemoteAccount(HttpMixin):
                     if not allow_fail:
                         raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                     else:
-                        msg = "Running ssh command exited with status %d and message '%s': %s" % (exit_status, stderr.read(), cmd)
-                        self._log(logging.DEBUG, msg)
+                        self._log(logging.DEBUG, "Running ssh command exited with status %d and message '%s': %s" % \
+                            (exit_status, stderr.read(), cmd)
             finally:
                 stdin.close()
                 stdout.close()
@@ -346,8 +346,8 @@ class RemoteAccount(HttpMixin):
                 if not allow_fail:
                     raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                 else:
-                    msg = "Running ssh command exited with status %d and message '%s': %s" % (exit_status, stderr.read(), cmd)
-                    self._log(logging.DEBUG, msg)
+                    self._log(logging.DEBUG, "Running ssh command exited with status %d and message '%s': %s" % \
+                        (exit_status, stderr.read(), cmd)
         finally:
             stdin.close()
             stdout.close()

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -252,7 +252,7 @@ class RemoteAccount(HttpMixin):
                     raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                 else:
                     self._log(logging.DEBUG, "Running ssh command '%s' exited with status %d and message: %s" %
-                              (cmd, exit_status, stderr.read())
+                              (cmd, exit_status, stderr.read()))
         finally:
             stdin.close()
             stdout.close()
@@ -305,7 +305,7 @@ class RemoteAccount(HttpMixin):
                         raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                     else:
                         self._log(logging.DEBUG, "Running ssh command '%s' exited with status %d and message: %s" %
-                                  (cmd, exit_status, stderr.read())
+                                  (cmd, exit_status, stderr.read()))
             finally:
                 stdin.close()
                 stdout.close()
@@ -347,7 +347,7 @@ class RemoteAccount(HttpMixin):
                     raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                 else:
                     self._log(logging.DEBUG, "Running ssh command '%s' exited with status %d and message: %s" %
-                              (cmd, exit_status, stderr.read())
+                              (cmd, exit_status, stderr.read()))
         finally:
             stdin.close()
             stdout.close()

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -251,8 +251,8 @@ class RemoteAccount(HttpMixin):
                 if not allow_fail:
                     raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                 else:
-                    self._log(logging.DEBUG, "Running ssh command exited with status %d and message '%s': %s" % \
-                        (exit_status, stderr.read(), cmd)
+                    self._log(logging.DEBUG, "Running ssh command '%s' exited with status %d and message: %s" %
+                              (cmd, exit_status, stderr.read())
         finally:
             stdin.close()
             stdout.close()
@@ -304,8 +304,8 @@ class RemoteAccount(HttpMixin):
                     if not allow_fail:
                         raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                     else:
-                        self._log(logging.DEBUG, "Running ssh command exited with status %d and message '%s': %s" % \
-                            (exit_status, stderr.read(), cmd)
+                        self._log(logging.DEBUG, "Running ssh command '%s' exited with status %d and message: %s" %
+                                  (cmd, exit_status, stderr.read())
             finally:
                 stdin.close()
                 stdout.close()
@@ -346,8 +346,8 @@ class RemoteAccount(HttpMixin):
                 if not allow_fail:
                     raise RemoteCommandError(self, cmd, exit_status, stderr.read())
                 else:
-                    self._log(logging.DEBUG, "Running ssh command exited with status %d and message '%s': %s" % \
-                        (exit_status, stderr.read(), cmd)
+                    self._log(logging.DEBUG, "Running ssh command '%s' exited with status %d and message: %s" %
+                              (cmd, exit_status, stderr.read())
         finally:
             stdin.close()
             stdout.close()


### PR DESCRIPTION
Current, when an SSH command fails, an exception will be raised only if `allow_fail` is false; if it is true, the result of any failed SSH command will be silently ignored.

This PR changes the behavior to log a debug message with the failure information when `allow_fail` is true. All other behavior is unchanged.