### PR TITLE
add env annotation

### DIFF
--- a/ducktape/mark/__init__.py
+++ b/ducktape/mark/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._mark import parametrize, matrix, defaults, ignore, parametrized, ignored  # NOQA
+from ._mark import parametrize, matrix, defaults, ignore, parametrized, ignored, env, is_env  # NOQA

--- a/ducktape/mark/_mark.py
+++ b/ducktape/mark/_mark.py
@@ -193,10 +193,7 @@ class Parametrize(Mark):
 class Env(Mark):
     def __init__(self, **kwargs):
         self.injected_args = kwargs
-        self.should_ignore = False
-        for key, value in kwargs.iteritems():
-            if os.environ[key] != value:
-                self.should_ignore = True
+        self.should_ignore = any(os.environ[key] != value for key, value in kwargs.iteritems())
 
     @property
     def name(self):

--- a/ducktape/mark/_mark.py
+++ b/ducktape/mark/_mark.py
@@ -204,7 +204,7 @@ class Env(Mark):
 
     def apply(self, seed_context, context_list):
         for ctx in context_list:
-            ctx.ingore = ctx.ignore or self.should_ignore
+            ctx.ignore = ctx.ignore or self.should_ignore
 
         return context_list
 

--- a/tests/mark/check_env.py
+++ b/tests/mark/check_env.py
@@ -15,8 +15,6 @@
 from ducktape.mark.mark_expander import MarkedFunctionExpander
 from ducktape.mark import env, is_env
 
-import pytest
-
 
 class CheckEnv(object):
 

--- a/tests/mark/check_env.py
+++ b/tests/mark/check_env.py
@@ -1,0 +1,38 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.mark.mark_expander import MarkedFunctionExpander
+from ducktape.mark import env, is_env
+
+import pytest
+
+
+class CheckEnv(object):
+
+    def check_has_env_annotation(self):
+        class C(object):
+            @env(JAVA_HOME="blah")
+            def function(self):
+                return 1
+
+        assert is_env(C.function)
+
+    def check_is_ignored_if_env_not_correct(self):
+        class C(object):
+            @env(JAVA_HOME="blah")
+            def function(self):
+                return 1
+
+        context_list = MarkedFunctionExpander(function=C.function, cls=C).expand()
+        assert context_list[0].ignore


### PR DESCRIPTION
Adding `@env` annotation so we can ignore tests when the environment isn't correct, i.e, incorrect version of java etc