### PR TITLE
Use separate tables for test results

### DIFF
--- a/ducktape/templates/report/report.css
+++ b/ducktape/templates/report/report.css
@@ -33,24 +33,24 @@ h1, h2, h3, h4, h5, h6 {
     padding: 2px;
 }
 
-#header_row {
+.header_row {
     font-weight: bold;
     color: white;
     background-color: #777;
 }
 
-#header_row th {
+.header_row th {
     border: 1px solid #777;
     padding: 2px; 
 }
 
-#report_table {
+.report_table {
     width: 80%;
     border-collapse: collapse;
     border: 1px solid #777;
 }
 
-#report_table td {
+.report_table td {
     border: 1px solid #777;
     padding: 2px;
 }

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -9,7 +9,9 @@
     <div id="heading"></div>
     <div id="summary_panel"></div>
     <div id="color_key_panel"></div>
-    <div id="test_panel"></div>
+    <div id="failed_test_panel"></div>
+    <div id="ignored_test_panel"></div>
+    <div id="passed_test_panel"></div>
     <script type="text/jsx">
       /* This small block makes it possible to use React dev tools in the Chrome browser */
       if (typeof window !== 'undefined') {
@@ -96,9 +98,9 @@
       var TestTable = React.createClass({
         render: function() {
           return (
-            <table id="report_table">
+            <table class="report_table">
               <thead>
-                <tr id="header_row">
+                <tr class="header_row">
                   <th colSpan='5' align='center'>Test</th>
                   <th colSpan='5' align='center'>Description</th>
                   <th colSpan='5' align='center'>Time</th>
@@ -163,7 +165,7 @@
         render: function() {
           return (
             <div>
-              <h2>Results</h2>
+              <h2>{this.props.title}</h2>
               <TestTable tests={this.props.tests}/>
             </div>
           );
@@ -185,12 +187,16 @@
 
       COLOR_KEYS=[%(test_status_names)s];
 
-      TESTS=[%(tests)s];
+      PASSED_TESTS=[%(passed_tests)s];
+      FAILED_TESTS=[%(failed_tests)s];
+      IGNORED_TESTS=[%(ignored_tests)s];
 
       React.render(<Heading heading={HEADING}/>, document.getElementById('heading'));
       React.render(<ColorKeyPanel test_status_names={COLOR_KEYS}/>, document.getElementById('color_key_panel'));
       React.render(<SummaryPanel summary_props={SUMMARY}/>, document.getElementById('summary_panel'));
-      React.render(<TestPanel tests={TESTS}/>, document.getElementById('test_panel'));
+      React.render(<TestPanel title="Failed Tests" tests={FAILED_TESTS}/>, document.getElementById('failed_test_panel'));
+      React.render(<TestPanel title="Ignored Tests" tests={IGNORED_TESTS}/>, document.getElementById('ignored_test_panel'));
+      React.render(<TestPanel title="Passed Tests" tests={PASSED_TESTS}/>, document.getElementById('passed_test_panel'));
     </script>
   </body>
 </html>

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -98,9 +98,9 @@
       var TestTable = React.createClass({
         render: function() {
           return (
-            <table class="report_table">
+            <table className="report_table">
               <thead>
-                <tr class="header_row">
+                <tr className="header_row">
                   <th colSpan='5' align='center'>Test</th>
                   <th colSpan='5' align='center'>Description</th>
                   <th colSpan='5' align='center'>Time</th>

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -187,10 +187,6 @@ class HTMLSummaryReporter(SummaryReporter):
         test_results_dir = os.path.abspath(result.results_dir)
         return test_results_dir[len(base_dir):]  # truncate the "absolute" portion
 
-    def append_result(self, result_string, result):
-        result_string += json.dumps(self.format_result(result))
-        result_string += ","
-
     def format_report(self):
         template = pkg_resources.resource_string(__name__, '../templates/report/report.html')
 

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -187,17 +187,31 @@ class HTMLSummaryReporter(SummaryReporter):
         test_results_dir = os.path.abspath(result.results_dir)
         return test_results_dir[len(base_dir):]  # truncate the "absolute" portion
 
+    def append_result(self, result_string, result):
+        result_string += json.dumps(self.format_result(result))
+        result_string += ","
+
     def format_report(self):
         template = pkg_resources.resource_string(__name__, '../templates/report/report.html')
 
         num_tests = len(self.results)
         num_passes = 0
-        result_string = ""
+        failed_result_string = ""
+        passed_result_string = ""
+        ignored_result_string = ""
+
         for result in self.results:
+            json_string = json.dumps(self.format_result(result))
             if result.test_status == PASS:
                 num_passes += 1
-            result_string += json.dumps(self.format_result(result))
-            result_string += ","
+                passed_result_string += json_string
+                passed_result_string += ","
+            elif result.test_status == FAIL:
+                failed_result_string += json_string
+                failed_result_string += ","
+            else:
+                ignored_result_string += json_string
+                ignored_result_string += ","
 
         args = {
             'ducktape_version': ducktape_version(),
@@ -207,7 +221,9 @@ class HTMLSummaryReporter(SummaryReporter):
             'num_ignored': self.results.num_ignored,
             'run_time': format_time(self.results.run_time_seconds),
             'session': self.results.session_context.session_id,
-            'tests': result_string,
+            'passed_tests': passed_result_string,
+            'failed_tests': failed_result_string,
+            'ignored_tests': ignored_result_string,
             'test_status_names': ",".join(["\'%s\'" % str(status) for status in [PASS, FAIL, IGNORE]])
         }
 


### PR DESCRIPTION
It's annoying searching through test results looking for failures, so this patch puts them in a separate table. The CSS changes probably need tweaking.