### PR TITLE
Switch to use tox to conveniently check coverage and code style

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+omit =
+    .git/*
+    .tox/*
+    docs/*
+    setup.py
+    test/*
+    tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,105 @@
-.idea/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-*.pyc
-*.ipynb
+# C extensions
+*.so
 
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
 *.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 
-.DS_Store
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
-# ducktape
-.ducktape/
-*results/
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
 
+# Unit test / coverage reports
+htmlcov/
+textcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
 docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -6,6 +6,7 @@ Misc
 
 Developer Install
 =================
+
 If you are are a ducktape developer, consider using the develop command instead of install. This allows you to make code changes without constantly reinstalling ducktape (see http://stackoverflow.com/questions/19048732/python-setup-py-develop-vs-install for more information)::
 
     cd ducktape
@@ -20,14 +21,15 @@ To uninstall::
 Unit Tests
 ==========
 
-You can run the tests via the setup.py script::
+You can run the tests with code coverage and style check using `tox <https://tox.readthedocs.io/en/latest/>`_::
 
-    python setup.py test
+    tox
 
-Alternatively, if you've installed pytest ``sudo pip install pytest`` you can run
-it directly on the ``tests`` directory::
+Alternatively, you can activate the virtualenv and run pytest and flake8 directly::
 
-    py.test tests
+    source ~/.virtualenvs/ducktape/bin/activate
+    pytest tests
+    flake8
 
 
 Windows

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -224,7 +224,7 @@ class RemoteAccount(HttpMixin):
         try:
             self.http_request(url, "GET", "", headers, timeout=.75)
             return True
-        except:
+        except Exception:
             return False
 
     def ssh(self, cmd, allow_fail=False):
@@ -360,7 +360,7 @@ class RemoteAccount(HttpMixin):
         try:
             self.ssh("kill -0 %s" % str(pid), allow_fail=False)
             return True
-        except:
+        except Exception:
             return False
 
     def signal(self, pid, sig, allow_fail=False):
@@ -519,7 +519,7 @@ class RemoteAccount(HttpMixin):
             # stat should follow symlinks
             path_stat = self.sftp_client.lstat(path)
             return stat.S_ISLNK(path_stat.st_mode)
-        except:
+        except Exception:
             return False
 
     def isdir(self, path):
@@ -527,7 +527,7 @@ class RemoteAccount(HttpMixin):
             # stat should follow symlinks
             path_stat = self.sftp_client.stat(path)
             return stat.S_ISDIR(path_stat.st_mode)
-        except:
+        except Exception:
             return False
 
     def exists(self, path):
@@ -549,7 +549,7 @@ class RemoteAccount(HttpMixin):
             # stat should follow symlinks
             path_stat = self.sftp_client.stat(path)
             return stat.S_ISREG(path_stat.st_mode)
-        except:
+        except Exception:
             return False
 
     def open(self, path, mode='r'):
@@ -596,7 +596,7 @@ class RemoteAccount(HttpMixin):
         """
         try:
             offset = int(self.ssh_output("wc -c %s" % log).split()[0])
-        except:
+        except Exception:
             offset = 0
         yield LogMonitor(self, log, offset)
 

--- a/ducktape/cluster/windows_remoteaccount.py
+++ b/ducktape/cluster/windows_remoteaccount.py
@@ -59,7 +59,7 @@ class WindowsRemoteAccount(RemoteAccount):
             ec2_instance_id = instance_id_file.read().strip()
             if not ec2_instance_id or ec2_instance_id == "":
                 raise Exception
-        except:
+        except Exception:
             raise Exception("Could not extract EC2 instance ID from local file: %s" % ec2_instance_id_path)
         finally:
             if instance_id_file:

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -171,7 +171,7 @@ def main():
             # Note that we're attaching a reference to cluster
             # only after test context objects have been instantiated
             ctx.cluster = cluster
-    except:
+    except Exception:
         print "Failed to load cluster: ", str(sys.exc_info()[0])
         print traceback.format_exc(limit=16)
         sys.exit(1)

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -221,12 +221,12 @@ class Service(TemplateRenderer):
 
             try:
                 self.stop_node(node)
-            except:
+            except Exception:
                 pass
 
             try:
                 self.clean_node(node)
-            except:
+            except Exception:
                 pass
 
         for node in self.nodes:

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+from contextlib import contextmanager
 import logging
 import os
 import re
@@ -469,3 +470,36 @@ class TestContext(object):
         # Release file handles held by logger
         if self._logger:
             close_logger(self._logger)
+
+
+@contextmanager
+def in_dir(path):
+    """ Changes working directory to given path. On exit, restore to original working directory. """
+    cwd = os.getcwd()
+
+    try:
+        os.chdir(path)
+        yield
+
+    finally:
+        os.chdir(cwd)
+
+
+@contextmanager
+def in_temp_dir():
+    """ Creates a temporary directory as the working directory. On exit, it is removed. """
+    with _new_temp_dir() as tmpdir:
+        with in_dir(tmpdir):
+            yield tmpdir
+
+
+@contextmanager
+def _new_temp_dir():
+    """ Create a temporary directory that is removed automatically """
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        yield tmpdir
+
+    finally:
+        shutil.rmtree(tmpdir)

--- a/ducktape/utils/terminal_size.py
+++ b/ducktape/utils/terminal_size.py
@@ -61,7 +61,7 @@ def _get_terminal_size_windows():
             sizex = right - left + 1
             sizey = bottom - top + 1
             return sizex, sizey
-    except:
+    except Exception:
         pass
 
 
@@ -72,7 +72,7 @@ def _get_terminal_size_tput():
         cols = int(subprocess.check_call(shlex.split('tput cols')))
         rows = int(subprocess.check_call(shlex.split('tput lines')))
         return (cols, rows)
-    except:
+    except Exception:
         pass
 
 
@@ -84,7 +84,7 @@ def _get_terminal_size_linux():
             cr = struct.unpack('hh',
                                fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
             return cr
-        except:
+        except Exception:
             pass
     cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
     if not cr:
@@ -92,11 +92,11 @@ def _get_terminal_size_linux():
             fd = os.open(os.ctermid(), os.O_RDONLY)
             cr = ioctl_GWINSZ(fd)
             os.close(fd)
-        except:
+        except Exception:
             pass
     if not cr:
         try:
             cr = (os.environ['LINES'], os.environ['COLUMNS'])
-        except:
+        except Exception:
             return None
     return int(cr[1]), int(cr[0])

--- a/ducktape/utils/util.py
+++ b/ducktape/utils/util.py
@@ -46,7 +46,7 @@ def package_is_installed(package_name):
     try:
         importlib.import_module(package_name)
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,13 +9,3 @@ python_functions=check_*
 
 # don't search inside any resources directory for unit tests
 norecursedirs = resources
-
-[flake8]
-exclude =
-    .git,
-    .eggs,
-    build,
-    __pycache__,
-    venv,
-
-max-line-length = 120

--- a/tests/logger/check_logger.py
+++ b/tests/logger/check_logger.py
@@ -52,9 +52,9 @@ class CheckLogger(object):
         initial_open_files = open_files()
 
         n_handles = 100
-        l = DummyFileLoggerMaker(self.temp_dir, n_handles)
+        log_maker = DummyFileLoggerMaker(self.temp_dir, n_handles)
         # accessing logger attribute lazily triggers configuration of logger
-        the_logger = l.logger
+        the_logger = log_maker.logger
 
         assert len(open_files()) == len(initial_open_files) + n_handles
         close_logger(the_logger)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,50 @@
+[tox]
+envlist = cover, style
+
+[testenv]
+# Consolidate all deps here instead of separately in test/style/cover so we
+# have a single env to work with, which makes debugging easier (like which env?).
+# Not as clean but easier to work with during development, which is better.
+deps =
+    flake8
+    mock
+    pytest
+    pytest-cov
+    pytest-xdist
+    psutil==4.1.0
+    memory_profiler==0.41
+    statistics==1.0.3.5
+    requests-testadapter==0.3.0
+install_command =
+    pip install -U {packages}
+recreate = False
+skipsdist = True
+usedevelop = True
+setenv =
+    PIP_PROCESS_DEPENDENCY_LINKS=1
+    PIP_DEFAULT_TIMEOUT=60
+    ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
+envdir = {homedir}/.virtualenvs/ducktape_{envname}
+commands =
+    pytest {env:PYTESTARGS:} {posargs}
+
+[testenv:py27]
+envdir = {homedir}/.virtualenvs/ducktape
+
+[testenv:style]
+basepython = python2.7
+envdir = {homedir}/.virtualenvs/ducktape
+commands =
+    flake8 --config tox.ini
+
+[testenv:cover]
+basepython = python2.7
+envdir = {homedir}/.virtualenvs/ducktape
+commands =
+    pytest {env:PYTESTARGS:} --cov ducktape --cov-report=xml --cov-report=html --cov-report=term --cov-report=annotate:textcov \
+                             --cov-fail-under=70
+
+[flake8]
+exclude = .git,.tox,.eggs,__pycache__,docs,build,dist
+ignore = E111,E121,W292,E123,E226
+max-line-length = 120


### PR DESCRIPTION
Other changes:
1. Updated gitignore
2. Added context managers in_dir/in_temp_dir to ensure compressed files are created in temp dir instead of cwd (ducktape repo)
3. Fix use of bare except as that is not necessary and may cause issues.

This also paves the way for adding Python 3.7 support later.  