### PR TITLE
ST-876: Only print warning when there is only one test cluster that used up all nodes

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -247,7 +247,7 @@ class TestRunner(object):
         :return None
         """
         allocated = self.cluster.alloc(test_context.expected_cluster_spec)
-        if len(self.cluster.available()) == 0 and self.max_parallel > 1:
+        if len(self.cluster.available()) == 0 and self.max_parallel > 1 and not self._test_cluster:
             self._log(logging.WARNING,
                       "Test %s is using entire cluster. It's possible this test has no associated cluster metadata."
                       % test_context.test_id)


### PR DESCRIPTION
With multiple test clusters, it will always trigger the warning as all the nodes will eventually be used. If one test cluster used all the nodes, then that's worth logging about.