### PR TITLE
Use builtin dir to populate template properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea

--- a/ducktape/template.py
+++ b/ducktape/template.py
@@ -21,6 +21,11 @@ import inspect
 
 class TemplateRenderer(object):
 
+    def _get_ctx(self):
+        ctx = {k: getattr(self.__class__, k) for k in dir(self.__class__)}
+        ctx.update(self.__dict__)
+        return ctx
+
     def render_template(self, template, **kwargs):
         """
         Render a template using the context of the current object, optionally with overrides.
@@ -31,8 +36,7 @@ class TemplateRenderer(object):
         """
         if not hasattr(template, 'render'):
             template = Template(template)
-        ctx = dict(self.__class__.__dict__)
-        ctx.update(self.__dict__)
+        ctx = self._get_ctx()
         return template.render(ctx, **kwargs)
 
     @staticmethod

--- a/tests/templates/test/check_render.py
+++ b/tests/templates/test/check_render.py
@@ -60,6 +60,26 @@ class CheckPackageSearchPath(object):
         package, path = TemplateRenderer._package_search_path("")
         assert package == "" and path == "templates"
 
+    def check_get_ctx(self):
+        class A(TemplateRenderer):
+            x = 'xxx'
+
+        class B(A):
+            y = 'yyy'
+
+        b = B()
+        b.instance = 'b instance'
+
+        ctx_a = A()._get_ctx()
+        assert ctx_a['x'] == 'xxx'
+        assert 'yyy' not in ctx_a
+        assert 'instance' not in ctx_a
+
+        ctx_b = b._get_ctx()
+        assert ctx_b['x'] == 'xxx'
+        assert ctx_b['y'] == 'yyy'
+        assert ctx_b['instance'] == 'b instance'
+
 
 class TemplateRenderingTest(Test):
     pass


### PR DESCRIPTION
The previously used __dict__ method will only show class properties
for current class, and not for superclasses
This change prepopulates the result dictionary with the builtin dir
which includes superclasses, and then applies the existing logic
in order to maintain behavior.