### PR TITLE
Fix bug in @cluster decorator

### DIFF
--- a/ducktape/mark/resource.py
+++ b/ducktape/mark/resource.py
@@ -16,6 +16,7 @@ import copy
 
 from ducktape.mark._mark import Mark
 
+CLUSTER_SPEC_KEYWORD = "cluster_spec"
 CLUSTER_SIZE_KEYWORD = "num_nodes"
 
 

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -27,8 +27,7 @@ from ducktape.utils.local_filesystem_utils import mkdir_p
 from ducktape.command_line.defaults import ConsoleDefaults
 from ducktape.services.service_registry import ServiceRegistry
 from ducktape.template import TemplateRenderer
-from ducktape.mark.resource import CLUSTER_SPEC_KEYWORD
-from ducktape.mark.resource import CLUSTER_SIZE_KEYWORD
+from ducktape.mark.resource import CLUSTER_SPEC_KEYWORD, CLUSTER_SIZE_KEYWORD
 from ducktape.tests.status import FAIL
 
 
@@ -285,7 +284,7 @@ class TestContext(object):
         :param file: file containing this module
         :param injected_args: a dict containing keyword args which will be passed to the test method
         :param cluster_use_metadata: dict containing information about how this test will use cluster resources,
-               to date, this only includes "num_nodes"
+               to date
         """
 
         self.session_context = kwargs.get("session_context")
@@ -302,7 +301,7 @@ class TestContext(object):
         self.ignore = kwargs.get("ignore", False)
 
         # cluster_use_metadata is a dict containing information about how this test will use cluster resources
-        # to date, this only includes "num_nodes"
+        # to date
         self.cluster_use_metadata = copy.copy(kwargs.get("cluster_use_metadata", {}))
 
         self.services = ServiceRegistry()

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -27,6 +27,7 @@ from ducktape.utils.local_filesystem_utils import mkdir_p
 from ducktape.command_line.defaults import ConsoleDefaults
 from ducktape.services.service_registry import ServiceRegistry
 from ducktape.template import TemplateRenderer
+from ducktape.mark.resource import CLUSTER_SPEC_KEYWORD
 from ducktape.mark.resource import CLUSTER_SIZE_KEYWORD
 from ducktape.tests.status import FAIL
 
@@ -384,8 +385,11 @@ class TestContext(object):
 
         :return:            A ClusterSpec object.
         """
+        cluster_spec = self.cluster_use_metadata.get(CLUSTER_SPEC_KEYWORD)
         cluster_size = self.cluster_use_metadata.get(CLUSTER_SIZE_KEYWORD)
-        if cluster_size is not None:
+        if cluster_spec is not None:
+            return cluster_spec
+        elif cluster_size is not None:
             return ClusterSpec.simple_linux(cluster_size)
         elif self.cluster is None:
             return ClusterSpec.empty()

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -283,8 +283,7 @@ class TestContext(object):
         :param function: the test method
         :param file: file containing this module
         :param injected_args: a dict containing keyword args which will be passed to the test method
-        :param cluster_use_metadata: dict containing information about how this test will use cluster resources,
-               to date
+        :param cluster_use_metadata: dict containing information about how this test will use cluster resources
         """
 
         self.session_context = kwargs.get("session_context")
@@ -301,7 +300,6 @@ class TestContext(object):
         self.ignore = kwargs.get("ignore", False)
 
         # cluster_use_metadata is a dict containing information about how this test will use cluster resources
-        # to date
         self.cluster_use_metadata = copy.copy(kwargs.get("cluster_use_metadata", {}))
 
         self.services = ServiceRegistry()

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -42,7 +42,7 @@ class CheckClusterUseAnnotation(object):
     def check_basic_usage_cluster_spec(self):
         num_nodes = 200
 
-        @cluster(cluster_spec=ClusterSpec.simple_linux(200))
+        @cluster(cluster_spec=ClusterSpec.simple_linux(num_nodes))
         def function():
             return "hi"
         assert hasattr(function, "marks")

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -16,6 +16,7 @@
 from ducktape.mark import parametrize, matrix, ignore
 from ducktape.mark.mark_expander import MarkedFunctionExpander
 from ducktape.mark.resource import cluster
+from ducktape.cluster.cluster_spec import ClusterSpec
 
 import pytest
 
@@ -37,6 +38,19 @@ class CheckClusterUseAnnotation(object):
         test_context_list = MarkedFunctionExpander(function=function).expand()
         assert len(test_context_list) == 1
         assert test_context_list[0].cluster_use_metadata == cluster_use_metadata
+
+    def check_basic_usage_cluster_spec(self):
+        num_nodes = 200
+
+        @cluster(cluster_spec=ClusterSpec.simple_linux(200))
+        def function():
+            return "hi"
+        assert hasattr(function, "marks")
+
+        test_context_list = MarkedFunctionExpander(function=function).expand()
+        assert len(test_context_list) == 1
+        assert len(test_context_list[0].expected_cluster_spec.nodes.os_to_nodes) == 1
+        assert len(test_context_list[0].expected_cluster_spec.nodes.os_to_nodes.get('linux')) == num_nodes
 
     def check_basic_usage_num_nodes(self):
         num_nodes = 200


### PR DESCRIPTION
There is a bug in current `@cluster` implementation, which only support `num_nodes`, but not `cluster_spec`.

Suppose we have, `@cluster(cluster_spec=ClusterSpec.simple_linux(3))` for the test, while only 2 linux nodes is up. We expect the test to fail as below
```
xxx_test requires more resources than are available in the whole cluster. linux nodes requested: 3. linux nodes available: 2
```
However, the test will continue, ignoring the "hint". 

Here is the fix. 
