### PR TITLE
adding SSHClient session expire check

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -191,10 +191,20 @@ class RemoteAccount(HttpMixin):
 
         return self._ssh_client
 
+    def _new_sftp_client(self):
+        self._sftp_client = self.ssh_client.open_sftp()
+
     @property
     def sftp_client(self):
         if not self._sftp_client:
-            self._sftp_client = self.ssh_client.open_sftp()
+            self._new_sftp_client()
+        else:
+            try:
+                self._sftp_client.listdir(".")
+            except Exception as e:
+                self._log(logging.DEBUG, "exception getting sftp_client (creating new client): %s" % str(e))
+                self._sftp_client.close()
+                self._new_sftp_client()
 
         return self._sftp_client
 

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -203,6 +203,8 @@ class RemoteAccount(HttpMixin):
     def sftp_client(self):
         if not self._sftp_client:
             self._set_sftp_client()
+        else:
+            self.ssh_client  # test connection
 
         return self._sftp_client
 

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -184,7 +184,9 @@ class RemoteAccount(HttpMixin):
             try:
                 transport = self._ssh_client.get_transport()
                 transport.send_ignore()
-            except:
+            except Exception as e:
+                self._log(logging.DEBUG, "exception getting ssh_client (creating new client): %s" % str(e))
+                self._ssh_client.close()
                 self._new_ssh_client()
 
         return self._ssh_client

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -180,9 +180,9 @@ class RemoteAccount(HttpMixin):
 
     @property
     def ssh_client(self):
-        if (self._ssh_client and
-            self._ssh_client.get_transport() and
-            self._ssh_client.get_transport().is_active()):
+        if (self._ssh_client
+                and self._ssh_client.get_transport()
+                and self._ssh_client.get_transport().is_active()):
             try:
                 transport = self._ssh_client.get_transport()
                 transport.send_ignore()

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -176,12 +176,13 @@ class RemoteAccount(HttpMixin):
         if self._ssh_client:
             self._ssh_client.close()
         self._ssh_client = client
+        self._set_sftp_client()
 
     @property
     def ssh_client(self):
-        if (self._ssh_client and
-            self._ssh_client.get_transport() and
-            self._ssh_client.get_transport().is_active()):
+        if (self._ssh_client
+            and self._ssh_client.get_transport()
+            and self._ssh_client.get_transport().is_active()):
             try:
                 transport = self._ssh_client.get_transport()
                 transport.send_ignore()
@@ -200,13 +201,7 @@ class RemoteAccount(HttpMixin):
 
     @property
     def sftp_client(self):
-        if self._sftp_client:
-            try:
-                self._sftp_client.listdir(".")
-            except Exception as e:
-                self._log(logging.DEBUG, "exception getting sftp_client (creating new client): %s" % str(e))
-                self._set_sftp_client()
-        else:
+        if not self._sftp_client:
             self._set_sftp_client()
 
         return self._sftp_client

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -180,9 +180,9 @@ class RemoteAccount(HttpMixin):
 
     @property
     def ssh_client(self):
-        if (self._ssh_client
-            and self._ssh_client.get_transport()
-            and self._ssh_client.get_transport().is_active()):
+        if (self._ssh_client and
+            self._ssh_client.get_transport() and
+            self._ssh_client.get_transport().is_active()):
             try:
                 transport = self._ssh_client.get_transport()
                 transport.send_ignore()


### PR DESCRIPTION
when running long-lived system tests I've run into `SSHException('SSH session not active')`

this change checks for a an active session both via the API and via actually sending a packet before returning the `SSHClient`