### PR TITLE
adding more logging during shutdown/copy/cleanup

### DIFF
--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -215,12 +215,15 @@ class RunnerClient(object):
 
         # always collect service logs whether or not we tear down
         # logs are typically removed during "clean" phase, so collect logs before cleaning
+        self.log(logging.DEBUG, "Copying logs from services...")
         self._do_safely(lambda: self.test.copy_service_logs(test_status), "Error copying service logs:")
 
         # clean up stray processes and persistent state
         if teardown_services:
+            self.log(logging.DEBUG, "Cleaning up services...")
             self._do_safely(services.clean_all, "Error cleaning services:")
 
+        self.log(logging.DEBUG, "Freeing nodes...")
         self._do_safely(self.test.free_nodes, "Error freeing nodes:")
 
     def log(self, log_level, msg, *args, **kwargs):

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -154,7 +154,11 @@ class Test(TemplateRenderer):
                     if test_status == FAIL or self.should_collect_log(log_name, service):
                         node_logs.append(log_dirs[log_name]["path"])
 
+                self.test_context.logger.debug("Preparing to copy logs from %s: %s" %
+                                               (node.account.hostname, node_logs))
+
                 if self.test_context.session_context.compress:
+                    self.test_context.logger.debug("Compressing logs...")
                     node_logs = self.compress_service_logs(node, service, node_logs)
 
                 if len(node_logs) > 0:
@@ -166,6 +170,7 @@ class Test(TemplateRenderer):
                         mkdir_p(dest)
 
                     # Try to copy the service logs
+                    self.test_context.logger.debug("Copying logs...")
                     try:
                         for log in node_logs:
                             node.account.copy_from(log, dest)


### PR DESCRIPTION
I normally watch both the session log & the `test_log.debug` to get an idea of how a test is doing...

For some larger tests, I was confused when after successfully stopping each node, the log would go quiet for quite a while... This made me assume something was broken when really it was just copying a bunch of log files from each service...

This PR seeks to make the shutdown process more transparent for anyone watching the `test_log.debug` for a test.