### PR TITLE
Add ability to run a sample of the full test suite

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import importlib
 import json
 import os
+import random
 from six import iteritems
 import sys
 import traceback
@@ -162,6 +163,16 @@ def main():
         for test in tests:
             print("    " + str(test))
         sys.exit(0)
+
+    if args_dict["sample"]:
+        print("Running a sample of %d tests" % args_dict["sample"])
+        try:
+            tests = random.sample(tests, args_dict["sample"])
+        except ValueError as e:
+            if args_dict["sample"] > len(tests):
+                print("sample size %d greater than number of tests %d; running all tests" % (args_dict["sample"], len(tests)))
+            else:
+                print("invalid sample size (%s), running all tests" % e)
 
     # Initializing the cluster is slow, so do so only if
     # tests are sure to be run

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -70,6 +70,8 @@ def create_ducktape_parser():
                         help="URL of a JSON report file containing stats from a previous test run. If specified, "
                              "this will be used when creating subsets of tests to divide evenly by total run time "
                              "instead of by number of tests.")
+    parser.add_argument("--sample", action="store", type=int,
+                        help="The size of a random test sample to run")
     return parser
 
 


### PR DESCRIPTION
This PR adds the --sample which, if provided, will give the size of a random sample of tests to run rather than all the tests that match the test path.