### PR TITLE
change fetch_externally_routable_ip for linux to support redhat 

### DIFF
--- a/ducktape/cluster/linux_remoteaccount.py
+++ b/ducktape/cluster/linux_remoteaccount.py
@@ -36,6 +36,6 @@ class LinuxRemoteAccount(RemoteAccount):
             cmd = "/sbin/ifconfig eth0 "
         else:
             cmd = "/sbin/ifconfig eth1 "
-        cmd += r"| grep 'inet addr' | tail -n 1 | egrep -o '[0-9\.]+' | head -n 1 2>&1"
+        cmd += r"| grep 'inet ' | tail -n 1 | egrep -o '[0-9\.]+' | head -n 1 2>&1"
         output = "".join(self.ssh_capture(cmd))
         return output.strip()


### PR DESCRIPTION
In order to support centOS/Redhat-based images we need to modify the grep, this will work for both "inet addr" (debian-based) and just "inet" (redhat)