### PR TITLE
Add Junit report support

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -29,7 +29,7 @@ from ducktape.command_line.parse_args import parse_args
 from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.loggermaker import close_logger
 from ducktape.tests.reporter import SimpleStdoutSummaryReporter, SimpleFileSummaryReporter, \
-    HTMLSummaryReporter, JSONReporter, XUnitReporter
+    HTMLSummaryReporter, JSONReporter, JUnitReporter
 from ducktape.tests.runner import TestRunner
 from ducktape.tests.session import SessionContext, SessionLoggerMaker
 from ducktape.tests.session import generate_session_id, generate_results_dir
@@ -201,7 +201,7 @@ def main():
         SimpleFileSummaryReporter(test_results),
         HTMLSummaryReporter(test_results),
         JSONReporter(test_results),
-        XUnitReporter(test_results)
+        JUnitReporter(test_results)
     ]
 
     for r in reporters:

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -29,7 +29,7 @@ from ducktape.command_line.parse_args import parse_args
 from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.loggermaker import close_logger
 from ducktape.tests.reporter import SimpleStdoutSummaryReporter, SimpleFileSummaryReporter, \
-    HTMLSummaryReporter, JSONReporter
+    HTMLSummaryReporter, JSONReporter, XUnitReporter
 from ducktape.tests.runner import TestRunner
 from ducktape.tests.session import SessionContext, SessionLoggerMaker
 from ducktape.tests.session import generate_session_id, generate_results_dir
@@ -200,7 +200,8 @@ def main():
         SimpleStdoutSummaryReporter(test_results),
         SimpleFileSummaryReporter(test_results),
         HTMLSummaryReporter(test_results),
-        JSONReporter(test_results)
+        JSONReporter(test_results),
+        XUnitReporter(test_results)
     ]
 
     for r in reporters:

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import json
 import os
 import shutil
+import xml.etree.ElementTree as ET
 
 import pkg_resources
 
@@ -147,6 +148,65 @@ class JSONReporter(object):
         report_file = os.path.abspath(os.path.join(self.results.session_context.results_dir, "report.json"))
         with open(report_file, "w") as f:
             f.write(json.dumps(self.results, cls=DucktapeJSONEncoder, sort_keys=True, indent=2, separators=(',', ': ')))
+
+
+class XUnitReporter(object):
+    def __init__(self, results):
+        self.results = results
+
+    def report(self):
+        report_file = os.path.abspath(os.path.join(self.results.session_context.results_dir, "report.xml"))
+        testsuites = {}
+
+        # First bucket by module_name and argregate counts
+        for result in self.results:
+            module_name = result.module_name
+            testsuites.setdefault(module_name, {})
+            # Set default values
+            testsuite = testsuites[module_name]
+            testsuite.setdefault('tests', 0)
+            testsuite.setdefault('skipped', 0)
+            testsuite.setdefault('failures', 0)
+            testsuite.setdefault('errors', 0)
+            testsuite.setdefault('testcases', []).append(result)
+
+            # Always increment total number of tests
+            testsuite['tests'] += 1
+            if result.test_status == FAIL:
+                testsuite['failures'] += 1
+            elif result.test_status == IGNORE:
+                testsuite['skipped'] += 1
+
+        total = self.results.num_failed + self.results.num_ignored + self.results.num_passed
+        # Now start building XML document
+        root = ET.Element('testsuites', attrib=dict(
+            name="ducktape", time=str(self.results.run_time_seconds),
+            tests=str(total), disabled="0", errors="0",
+            failures=str(self.results.num_failed)
+        ))
+        for module_name, testsuite in testsuites.items():
+            xml_testsuite = ET.SubElement(root, 'testsuite', attrib=dict(
+                name=module_name, tests=str(testsuite['tests']), disabled="0",
+                errors="0", failures=str(testsuite['failures']), skipped=str(testsuite['skipped'])
+            ))
+            for test in testsuite['testcases']:
+                xml_testcase = ET.SubElement(xml_testsuite, 'testcase', attrib=dict(
+                    name=test.test_id, classname=test.cls_name, time=str(test.run_time_seconds),
+                    status=str(test.test_status), assertions=""
+                ))
+                if test.test_status == FAIL:
+                    xml_failure = ET.SubElement(xml_testcase, 'failure', attrib=dict(
+                        message=test.summary.splitlines()[0]
+                    ))
+                    xml_failure.text = test.summary
+                elif test.test_status == IGNORE:
+                    ET.SubElement(xml_testcase, 'skipped')
+
+        with open(report_file, "w") as f:
+            content = ET.tostring(root)
+            if isinstance(content, bytes):
+                content = content.decode("utf-8")
+            f.write(content)
 
 
 class HTMLSummaryReporter(SummaryReporter):

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -190,8 +190,14 @@ class XUnitReporter(object):
                 errors="0", failures=str(testsuite['failures']), skipped=str(testsuite['skipped'])
             ))
             for test in testsuite['testcases']:
+                # Since we're already aware of module_name and cls_name, strip that prefix off
+                full_name = "{module_name}.{cls_name}.".format(module_name=module_name, cls_name=test.cls_name)
+                if test.test_id.startswith(full_name):
+                    name = test.test_id[len(full_name):]
+                else:
+                    name = test.test_id
                 xml_testcase = ET.SubElement(xml_testsuite, 'testcase', attrib=dict(
-                    name=test.test_id, classname=test.cls_name, time=str(test.run_time_seconds),
+                    name=name, classname=test.cls_name, time=str(test.run_time_seconds),
                     status=str(test.test_status), assertions=""
                 ))
                 if test.test_status == FAIL:

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -150,7 +150,7 @@ class JSONReporter(object):
             f.write(json.dumps(self.results, cls=DucktapeJSONEncoder, sort_keys=True, indent=2, separators=(',', ': ')))
 
 
-class XUnitReporter(object):
+class JUnitReporter(object):
     def __init__(self, results):
         self.results = results
 

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -108,20 +108,20 @@ class CheckRunner(object):
         passed = tree.findall("./testsuite/testcase/[@status='pass']")
         assert len(passed) == 1
         assert passed[0].get("classname") == "TestThingy"
-        assert passed[0].get("name") == "tests.runner.resources.test_thingy.TestThingy.test_pi"
+        assert passed[0].get("name") == "test_pi"
 
         failures = tree.findall("./testsuite/testcase/[@status='fail']")
         assert len(failures) == 1
         assert failures[0].get("classname") == "TestThingy"
-        assert failures[0].get("name") == "tests.runner.resources.test_thingy.TestThingy.test_failure"
+        assert failures[0].get("name") == "test_failure"
 
         ignores = tree.findall("./testsuite/testcase/[@status='ignore']")
         assert len(ignores) == 2
         assert ignores[0].get("classname") == "TestThingy"
         assert ignores[1].get("classname") == "TestThingy"
 
-        assert ignores[0].get("name") == "tests.runner.resources.test_thingy.TestThingy.test_ignore1"
-        assert ignores[1].get("name") == "tests.runner.resources.test_thingy.TestThingy.test_ignore2.x=5"
+        assert ignores[0].get("name") == "test_ignore1"
+        assert ignores[1].get("name") == "test_ignore2.x=5"
 
     def check_exit_first(self):
         """Confirm that exit_first in session context has desired effect of preventing any tests from running

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -23,7 +23,7 @@ from tests.runner.resources.test_fails_to_init import FailsToInitTest
 from tests.runner.resources.test_fails_to_init_in_setup import FailsToInitInSetupTest
 from .resources.test_thingy import TestThingy
 from .resources.test_failing_tests import FailingTest
-from ducktape.tests.reporter import XUnitReporter
+from ducktape.tests.reporter import JUnitReporter
 
 
 from mock import Mock
@@ -86,7 +86,7 @@ class CheckRunner(object):
         result_with_data = [r for r in results if r.data is not None][0]
         assert result_with_data.data == {"data": 3.14159}
 
-    def check_runner_report_xunit(self):
+    def check_runner_report_junit(self):
         """Check we can serialize results into a xunit xml format. Also ensures that the XML report
         adheres to the Junit spec using xpath queries"""
         mock_cluster = LocalhostCluster(num_nodes=1000)
@@ -97,7 +97,7 @@ class CheckRunner(object):
         runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
 
         results = runner.run_all_tests()
-        XUnitReporter(results).report()
+        JUnitReporter(results).report()
         xml_report = os.path.join(session_context.results_dir, "report.xml")
         assert os.path.exists(xml_report)
         tree = ET.parse(xml_report)

--- a/tests/runner/resources/test_thingy.py
+++ b/tests/runner/resources/test_thingy.py
@@ -35,3 +35,6 @@ class TestThingy(Test):
     @parametrize(x=5)
     def test_ignore2(self, x=2):
         pass
+
+    def test_failure(self):
+        raise Exception("This failed")


### PR DESCRIPTION
Long standing request internally to spit out an XML report in junit format so it can be slurped up by CI-like systems (Jenkins).

### Testing

I modified the `check_runner_report_xunit` test to spit out an XML under `/tmp`, and ran it through `xmllint` against the Junit.xsd (https://llg.cubic.org/docs/junit/) schema for validation:

```
aegelhofer@Andrew-Egelhofer's- ducktape % xmllint --schema /tmp/ducktape-resuls/xunit.xsd /tmp/ducktape-resuls/report.xml --format
<?xml version="1.0"?>
<testsuites disabled="0" errors="0" failures="1" name="ducktape" tests="4" time="0.87104511261">
  <testsuite disabled="0" errors="0" failures="1" name="tests.runner.resources.test_thingy" skipped="2" tests="4">
    <testcase assertions="" classname="TestThingy" name="tests.runner.resources.test_thingy.TestThingy.test_pi" status="pass" time="0.00725317001343"/>
    <testcase assertions="" classname="TestThingy" name="tests.runner.resources.test_thingy.TestThingy.test_ignore1" status="ignore" time="0.0">
      <skipped/>
    </testcase>
    <testcase assertions="" classname="TestThingy" name="tests.runner.resources.test_thingy.TestThingy.test_ignore2.x=5" status="ignore" time="0.0">
      <skipped/>
    </testcase>
    <testcase assertions="" classname="TestThingy" name="tests.runner.resources.test_thingy.TestThingy.test_failure" status="fail" time="0.00793695449829">
      <failure message="This failed">This failed
Traceback (most recent call last):
  File "/Users/aegelhofer/workspace/ducktape/ducktape/tests/runner_client.py", line 134, in run
    data = self.run_test()
  File "/Users/aegelhofer/workspace/ducktape/ducktape/tests/runner_client.py", line 192, in run_test
    return self.test_context.function(self.test)
  File "/Users/aegelhofer/workspace/ducktape/tests/runner/resources/test_thingy.py", line 40, in test_failure
    raise Exception("This failed")
Exception: This failed
</failure>
    </testcase>
  </testsuite>
</testsuites>
/tmp/ducktape-resuls/report.xml validates
```