### PR TITLE
MINOR: Print out stdout output on non-zero exit code in ssh_capture()

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -315,8 +315,9 @@ class RemoteAccount(HttpMixin):
 
         def output_generator():
 
+            stdout_lines = []
             for line in iter(stdout.readline, ''):
-
+                stdout_lines.append(line)
                 if callback is None:
                     yield line
                 else:
@@ -324,11 +325,12 @@ class RemoteAccount(HttpMixin):
             try:
                 exit_status = stdout.channel.recv_exit_status()
                 if exit_status != 0:
+                    full_output = "stderr: {}\nstdout: {}".format(stderr.read(), ''.join(stdout_lines))
                     if not allow_fail:
-                        raise RemoteCommandError(self, cmd, exit_status, stderr.read())
+                        raise RemoteCommandError(self, cmd, exit_status, full_output)
                     else:
                         self._log(logging.DEBUG, "Running ssh command '%s' exited with status %d and message: %s" %
-                                  (cmd, exit_status, stderr.read()))
+                                  (cmd, exit_status, full_output))
             finally:
                 stdin.close()
                 stdout.close()


### PR DESCRIPTION
This patch changes the ssh_capture command to additionally print out stdout output on non-zero exit codes. While it's expected for the command to print out its error in stderr, not all do - Kafka's tools (e.g kafka-topics) do not, for example.
