### PR TITLE
Fix failure to load report.html via https

### DIFF
--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="http://fb.me/react-0.13.1.min.js"></script>
-    <script src="http://fb.me/JSXTransformer-0.13.1.js"></script>
+    <script src="https://fb.me/react-0.13.1.min.js"></script>
+    <script src="https://fb.me/JSXTransformer-0.13.1.js"></script>
   </head>
   <link rel="stylesheet" href="report.css" type="text/css">
   <body>


### PR DESCRIPTION
The report.html has a bug that it's failed to load via https. And browser console complains 
```
Mixed Content: The page at 'https://confluent-kafka-system-test-results.s3-us-west-2.amazonaws.com/2020-08-09--001.1596962320--confluentinc--master--7f21a17d2/report.html' was loaded over HTTPS, but requested an insecure script 'http://fb.me/react-0.13.1.min.js'. This request has been blocked; the content must be served over HTTPS.
Mixed Content: The page at 'https://confluent-kafka-system-test-results.s3-us-west-2.amazonaws.com/2020-08-09--001.1596962320--confluentinc--master--7f21a17d2/report.html' was loaded over HTTPS, but requested an insecure script 'http://fb.me/JSXTransformer-0.13.1.js'. This request has been blocked; the content must be served over HTTPS.
```
For example, checkout https://confluent-kafka-system-test-results.s3-us-west-2.amazonaws.com/2020-08-09--001.1596962320--confluentinc--master--7f21a17d2/report.html and http://confluent-kafka-system-test-results.s3-us-west-2.amazonaws.com/2020-08-09--001.1596962320--confluentinc--master--7f21a17d2/report.html

I also found this issue because I'm hosting the result reports with my company's internal hosted TeamCity CI server, and its connection is mandatory https. Therefore, it's always a blank page when I open report.html from our TeamCity.

Closes #242.