### PR TITLE
Add tox testing support for py38

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, cover, style
+envlist = py27, py36, py37, py38, cover, style
 
 [testenv]
 # Consolidate all deps here instead of separately in test/style/cover so we
@@ -37,14 +37,17 @@ envdir = {homedir}/.virtualenvs/ducktape-py36
 [testenv:py37]
 envdir = {homedir}/.virtualenvs/ducktape-py37
 
+[testenv:py38]
+envdir = {homedir}/.virtualenvs/ducktape-py38
+
 [testenv:style]
-basepython = python3.7
+basepython = python3.8
 envdir = {homedir}/.virtualenvs/ducktape
 commands =
     flake8 --config tox.ini
 
 [testenv:cover]
-basepython = python3.7
+basepython = python3.8
 envdir = {homedir}/.virtualenvs/ducktape
 commands =
     pytest {env:PYTESTARGS:} --cov ducktape --cov-report=xml --cov-report=html --cov-report=term --cov-report=annotate:textcov \


### PR DESCRIPTION
Minor addition, but depends on confluentinc/confluent-docker-build-images#106 (merged and deployed) before CI will pass. style and cover targets seem best to just keep aligned with latest version, so retargeted those as well.