### PR TITLE
Fix an error where ducktape hangs up if the test fails with unicode error message

### DIFF
--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -136,11 +136,11 @@ class RunnerClient(object):
             self.log(logging.INFO, "PASS")
 
         except BaseException as e:
-            err_trace = self._exc_msg(e)
-            self.log(logging.INFO, "FAIL: " + err_trace)
-
+            # mark the test as failed before doing anything else
             test_status = FAIL
+            err_trace = self._exc_msg(e)
             summary += err_trace
+            self.log(logging.INFO, "FAIL: " + err_trace)
 
         finally:
             self.teardown_test(teardown_services=not self.session_context.no_teardown, test_status=test_status)

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -85,25 +85,6 @@ class RunnerClient(object):
         self.test_context.test_index = self.test_index
 
         self.send(self.message.running())
-        try:
-            # Run the test
-            result = self.execute_test()
-        except BaseException as e:
-            # Report any exception from executing the test.
-            # execute_test() should catch all test-related exceptions,
-            # while this part should catch any framework-related exceptions
-            self.log(logging.WARN, "Error running test " + str(self.test_metadata) + "\n" + self._exc_msg(e))
-        finally:
-            # Tell the server we are finished
-            self._do_safely(lambda: self.send(self.message.finished(result=result)),
-                            "Problem sending FINISHED message for " + str(self.test_metadata) + ":\n")
-            # Release test_context resources only after creating the result and finishing logging activity
-            # The Sender object uses the same logger, so we postpone closing until after the finished message is sent
-            self.test_context.close()
-            self.test_context = None
-            self.test = None
-
-    def execute_test(self):
         if self.test_context.ignore:
             # Skip running this test, but keep track of the fact that we ignored it
             result = TestResult(self.test_context,
@@ -113,13 +94,10 @@ class RunnerClient(object):
                                 start_time=time.time(),
                                 stop_time=time.time())
             result.report()
-            return result
-            # # Tell the server we are finished
-            # self.send(self.message.finished(result=result))
-            # return
+            # Tell the server we are finished
+            self.send(self.message.finished(result=result))
+            return
 
-        # Results from this test, as well as logs will be dumped here
-        mkdir_p(TestContext.results_dir(self.test_context, self.test_index))
         start_time = -1
         stop_time = -1
         test_status = PASS
@@ -127,6 +105,8 @@ class RunnerClient(object):
         data = None
 
         try:
+            # Results from this test, as well as logs will be dumped here
+            mkdir_p(TestContext.results_dir(self.test_context, self.test_index))
             # Instantiate test
             self.test = self.test_context.cls(self.test_context)
 
@@ -186,7 +166,14 @@ class RunnerClient(object):
             self.log(logging.INFO, "Data: %s" % str(result.data))
 
             result.report()
-            return result
+            # Tell the server we are finished
+            self._do_safely(lambda: self.send(self.message.finished(result=result)),
+                            "Problem sending FINISHED message for " + str(self.test_metadata) + ":\n")
+            # Release test_context resources only after creating the result and finishing logging activity
+            # The Sender object uses the same logger, so we postpone closing until after the finished message is sent
+            self.test_context.close()
+            self.test_context = None
+            self.test = None
 
     def setup_test(self):
         """start services etc"""

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -184,4 +184,3 @@ class CheckRunner(object):
         assert results.num_failed == 2
         assert results.num_passed == 0
         assert results.num_ignored == 2
-

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import patch
+try:
+    from unittest.mock import patch, MagicMock  # noqa: F401
+except ImportError:
+    from mock import patch, MagicMock  # noqa: F401
 
 from ducktape.tests.runner_client import RunnerClient
 from ducktape.tests.test import TestContext

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import patch
 
+from ducktape.tests.runner_client import RunnerClient
 from ducktape.tests.test import TestContext
 from ducktape.tests.runner import TestRunner
 from ducktape.mark.mark_expander import MarkedFunctionExpander
@@ -158,3 +160,28 @@ class CheckRunner(object):
         assert results.num_failed == 4
         assert results.num_passed == 0
         assert results.num_ignored == 0
+
+    @patch('ducktape.tests.runner_client.mkdir_p')
+    @patch.object(RunnerClient, '_exc_msg')
+    def check_sends_result_when_internal_error(self, exc_msg_mock, mkdir_p_mock):
+        """Validates that any framework error when executing the test
+        doesn't prevent sending the result and completing the test"""
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context()
+
+        # mock an error creating test directory - this will make both test_pi and test_failure fail before execution
+        mkdir_p_mock.side_effect = Exception
+        # mock an error reporting test failure - this should not prevent subsequent tests from execution and mark
+        # failed test as failed correctly
+        exc_msg_mock.side_effect = Exception
+        test_methods = [TestThingy.test_pi, TestThingy.test_ignore1, TestThingy.test_ignore2, TestThingy.test_failure]
+        ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=TestThingy, test_methods=test_methods,
+                                   cluster=mock_cluster, session_context=session_context)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+
+        results = runner.run_all_tests()
+        assert len(results) == 4
+        assert results.num_failed == 2
+        assert results.num_passed == 0
+        assert results.num_ignored == 2
+


### PR DESCRIPTION
Fix exception when reporting an exception.

Some of the confluent system tests raise an exception with unicode characters. Duckrape calls `str` on that exception, which fails and raises an exception - and it all happens inside the `except` clause, which makes the rest of the code in the `run` method skipped - this includes sending the `finished` message back to the server; this in turn makes the server wait indefinitely for the test to finish.

Fix is two-fold:
- use repr(exc) instead of str(exc) - repr won't raise on unicode and convert it correctly.
- send the result to the server in the `finally` block rather than outside of it; also moved folder creation inside the `try`, so that even if it fails, we still send the result back. Most of the things are now inside try-finally block, so it seems like uncaught errors can likely happen only inside `finally` block itself - which is quite well guarded against those.
- ~~wrap the whole test execution flow into another layer of try-except-finally - inner layer will catch and report the actual failure of the test; outer layer will catch and report errors in the framework itself, or at least that's the intention.~~
    - ~~**Open question - should we mark test as failed if we encounter framework error?**~~
    - Removed the extra try-finally block and instead moved sending of the result into the main `finally` block 
    - after looking at initial implementation some more, it wasn't that good, since it expected the `result` object to be present, which won't be the case if exception happened in the execute method.

Existing unit tests pass.
Added an extra unit test to cover the case of exception message breaking.
Verified with ducktape systests.
Verified with confluent system tests.
Checked that porting to 0.8.x and master is a direct merge
