### PR TITLE
Support specifying test params in test discovery symbols

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,9 @@
 Install
 =======
 
-1. Install `cryptography`_ (used by `paramiko` which Ducktape depends on), this may have non-python external requirements
+1. Ducktape requires python 3.7 or later.
+
+2. Install `cryptography`_ (used by `paramiko` which Ducktape depends on), this may have non-python external requirements
 
 .. _cryptography: https://cryptography.io/en/latest/installation
 
@@ -21,9 +23,9 @@ Install
         sudo yum install gcc libffi-devel python-devel openssl-devel
 
 
-2. As a general rule, it's recommended to use an isolation tool such as ``virtualenv``
+3. As a general rule, it's recommended to use an isolation tool such as ``virtualenv``
 
-3. Install Ducktape::
+4. Install Ducktape::
 
     pip install ducktape
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 Sphinx==1.5.3
 sphinx-argparse==0.1.17
 sphinx-rtd-theme==0.2.4
-boto3==1.9.0
-pycryptodome==3.7.0
+boto3==1.15.9
+pycryptodome==3.9.8
 pywinrm==0.2.2

--- a/docs/run_tests.rst
+++ b/docs/run_tests.rst
@@ -9,12 +9,14 @@ Running Tests
 
 ducktape discovers and runs tests in the path(s) provided.
 You can specify a folder with tests, a specific test file or even a specific class or test method, via absolute or
-relative paths::
+relative paths. You can optionally specify a specific set of parameters
+for tests with ``@parametrize`` or ``@matrix`` annotations::
 
-    ducktape <relative_path_to_testdirectory>               # e.g. ducktape dir/tests
-    ducktape <relative_path_to_file>                        # e.g. ducktape dir/tests/my_test.py
-    ducktape <path_to_test>[::SomeTestClass]                # e.g. ducktape dir/tests/my_test.py::TestA
-    ducktape <path_to_test>[::SomeTestClass[.test_method]]  # e.g. ducktape dir/tests/my_test.py::TestA.test_a
+    ducktape <relative_path_to_testdirectory>                   # e.g. ducktape dir/tests
+    ducktape <relative_path_to_file>                            # e.g. ducktape dir/tests/my_test.py
+    ducktape <path_to_test>[::SomeTestClass]                    # e.g. ducktape dir/tests/my_test.py::TestA
+    ducktape <path_to_test>[::SomeTestClass[.test_method]]      # e.g. ducktape dir/tests/my_test.py::TestA.test_a
+    ducktape <path_to_test>[::TestClass[.method[@params_json]]] # e.g. ducktape 'dir/tests/my_test.py::TestA.test_a@{"x": 100}'
 
 
 Excluding Tests
@@ -38,6 +40,7 @@ via YAML file
     my_test_suite:
         - ./my_tests_dir/  # paths are relative to the test suite file location
         - ./another_tests_dir/test_file.py::TestClass.test_method  # same syntax as passing tests directly to ducktape
+        - './another_tests_dir/test_file.py::TestClass.parametrized_method@{"x": 100}'  # params are supported too
         - ./third_tests_dir/prefix_*.py  # basic globs are supported (* and ? characters)
 
     # each YAML file can contain one or more test suites:

--- a/ducktape/tests/loader.py
+++ b/ducktape/tests/loader.py
@@ -259,7 +259,7 @@ class TestLoader(object):
                 try:
                     injected_args = json.loads(injected_args_str)
                 except Exception as e:
-                    raise LoaderException("Invalid test params: " + injected_args_str) from e
+                    raise LoaderException("Invalid discovery symbol: cannot parse params: " + injected_args_str) from e
             else:
                 injected_args = None
         else:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(name="ducktape",
       url="http://github.com/confluentinc/ducktape",
       packages=find_packages(),
       package_data={'ducktape': ['templates/report/*']},
+      python_requires='>= 3.7',
       install_requires=['jinja2==2.11.2',
                         'boto3==1.15.9',
                         # jinja2 pulls in MarkupSafe with a > constraint, but we need to constrain it for compatibility

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -366,11 +366,18 @@ class CheckTestLoader(object):
         with pytest.raises(LoaderException, match='No tests to run'):
             loader.load(included)
 
-    def check_test_loader_raises_on_invalid_parameters_syntax(self):
+    @pytest.mark.parametrize("symbol", [
+        # no class
+        'test_decorated.py::.test_thing'
+        # no method
+        'test_decorated.py::TestMatrix@{"x": 1, "y": "test "}'
+        # invalid json in params
+        'test_decorated.py::TestMatrix.test_thing@{x: 1,"y": "test "}'
+    ])
+    def check_test_loader_raises_on_malformed_test_discovery_symbol(self, symbol):
         loader = TestLoader(self.SESSION_CONTEXT, logger=Mock())
-        # json is invalid - no quotes around x
-        included = [os.path.join(discover_dir(), 'test_decorated.py::TestMatrix.test_thing@{x: 1,"y": "test "}')]
-        with pytest.raises(LoaderException, match='Invalid test params'):
+        included = [os.path.join(discover_dir(), symbol)]
+        with pytest.raises(LoaderException, match='Invalid discovery symbol'):
             loader.load(included)
 
     def check_test_loader_exclude_with_injected_args(self):

--- a/tests/loader/resources/loader_test_directory/invalid_test_suites/test_suite_with_malformed_params.yml
+++ b/tests/loader/resources/loader_test_directory/invalid_test_suites/test_suite_with_malformed_params.yml
@@ -1,0 +1,3 @@
+non_existent_file_suit:
+  included:
+    - 'test_decorated.py::TestMatrix.test_thing@[{x: 1,y: "test "}]'  # this json won't parse because no quotes

--- a/tests/loader/resources/loader_test_directory/test_decorated.py
+++ b/tests/loader/resources/loader_test_directory/test_decorated.py
@@ -16,7 +16,7 @@ from ducktape.tests.test import Test
 from ducktape.mark import matrix
 from ducktape.mark import parametrize
 
-NUM_TESTS = 15
+NUM_TESTS = 17
 
 
 class TestMatrix(Test):
@@ -42,5 +42,13 @@ class TestParametrized(Test):
     @parametrize(x=1, y=2)
     @parametrize(x="abc", y=[])
     def test_thing(self, x, y):
+        """2 tests"""
+        pass
+
+
+class TestObjectParameters(Test):
+    @parametrize(d={'a': 'A'}, lst=['whatever'])
+    @parametrize(d={'z': 'Z'}, lst=['something'])
+    def test_thing(self, d, lst):
         """2 tests"""
         pass

--- a/tests/loader/resources/loader_test_directory/test_suite_decorated.yml
+++ b/tests/loader/resources/loader_test_directory/test_suite_decorated.yml
@@ -1,0 +1,5 @@
+test_suite_decorated:
+  - 'test_decorated.py::TestMatrix.test_thing@[{"x": 1,"y": "test "}, {"x": 2, "y": "test "}]'  # 2 tests
+  - 'test_decorated.py::TestStackedMatrix.test_thing@{"x": 100, "y": 100}'  # ignored, there are no such params in code
+
+# total: 2 tests

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-try:
-    from unittest.mock import patch, MagicMock  # noqa: F401
-except ImportError:
-    from mock import patch, MagicMock  # noqa: F401
+
+from unittest.mock import patch
 
 from ducktape.tests.runner_client import RunnerClient
 from ducktape.tests.test import TestContext
@@ -164,26 +162,21 @@ class CheckRunner(object):
         assert results.num_passed == 0
         assert results.num_ignored == 0
 
-    @patch('ducktape.tests.runner_client.mkdir_p')
-    @patch.object(RunnerClient, '_exc_msg')
-    def check_sends_result_when_internal_error(self, exc_msg_mock, mkdir_p_mock):
-        """Validates that any framework error when executing the test
-        doesn't prevent sending the result and completing the test"""
+    # mock an error reporting test failure - this should not prevent subsequent tests from execution and mark
+    # failed test as failed correctly
+    @patch.object(RunnerClient, '_exc_msg', side_effect=Exception)
+    def check_sends_result_when_error_reporting_exception(self, exc_msg_mock):
+        """Validates that an error when reporting an exception in the test doesn't prevent subsequent tests
+        from executing"""
         mock_cluster = LocalhostCluster(num_nodes=1000)
         session_context = tests.ducktape_mock.session_context()
-
-        # mock an error creating test directory - this will make both test_pi and test_failure fail before execution
-        mkdir_p_mock.side_effect = Exception
-        # mock an error reporting test failure - this should not prevent subsequent tests from execution and mark
-        # failed test as failed correctly
-        exc_msg_mock.side_effect = Exception
-        test_methods = [TestThingy.test_pi, TestThingy.test_ignore1, TestThingy.test_ignore2, TestThingy.test_failure]
+        test_methods = [TestThingy.test_failure, TestThingy.test_pi]
         ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=TestThingy, test_methods=test_methods,
                                    cluster=mock_cluster, session_context=session_context)
         runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
 
         results = runner.run_all_tests()
-        assert len(results) == 4
-        assert results.num_failed == 2
-        assert results.num_passed == 0
-        assert results.num_ignored == 2
+        assert len(results) == 2
+        assert results.num_failed == 1
+        assert results.num_passed == 1
+        assert results.num_ignored == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, py38, cover, style
+envlist = py37, py38, cover, style
 
 [testenv]
 # Consolidate all deps here instead of separately in test/style/cover so we
@@ -27,12 +27,6 @@ setenv =
 envdir = {homedir}/.virtualenvs/ducktape_{envname}
 commands =
     pytest {env:PYTESTARGS:} {posargs}
-
-[testenv:py27]
-envdir = {homedir}/.virtualenvs/ducktape-py2
-
-[testenv:py36]
-envdir = {homedir}/.virtualenvs/ducktape-py36
 
 [testenv:py37]
 envdir = {homedir}/.virtualenvs/ducktape-py37


### PR DESCRIPTION
You can now append `@{"x": 100}` to a test discovery symbol after a method.
This behaves as a filter as opposed to `--parameters` flag which directly passes the params.
For example, this method:
```
@matrix(x=[1, 2, 3])
def some_test(x):
   ...
```
you can run with `@{"x": 1}` but not with `@{"x": 1000}` because there is no such param declared in the `@matrix` annotation. It won't crash, but simply won't find test that matches.

There is, of course, a limitation that parameters must be json-compatible for this to work, similarly to `--parameters` flag.

Additionally:
- removed py27 from tox and clarified that only python 3.7+ is supported. This has been the case for 0.8.x branch already, but not clarified anywhere.
- updated the docs
- fixed a test that was failing on python3.8 due to different behavior of the `@patch` annotation - and the test wasn't that good in the first place, it is more focused now.