### PR TITLE
added CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Make Confluent Quality team the default reviewers (but not required reviewers) on all PRs.
+* @confluentinc/quality-eng


### PR DESCRIPTION
This should prevent any additional PRs sitting in limbo for weeks/months, while at the same time not imposing any restrictions against merging those PRs.