### PR TITLE
Print a warning if test is not using all requested nodes

### DIFF
--- a/ducktape/__main__.py
+++ b/ducktape/__main__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ducktape
+from ducktape.command_line import main
 
 if __name__ == "__main__":
-    ducktape.command_line.main.main()
+    main.main()

--- a/ducktape/cluster/cluster.py
+++ b/ducktape/cluster/cluster.py
@@ -36,6 +36,9 @@ class Cluster(object):
     system that can describe available resources and mediates reservations of those resources.
     """
 
+    def __init__(self):
+        self.max_used_nodes = 0
+
     def __len__(self):
         """Size of this cluster object. I.e. number of 'nodes' in the cluster."""
         return self.available().size() + self.used().size()
@@ -46,6 +49,19 @@ class Cluster(object):
 
         :param cluster_spec:                    A ClusterSpec describing the nodes to be allocated.
         :throws InsufficientResources:          If the nodes cannot be allocated.
+        :return:                                Allocated nodes spec
+        """
+        allocated = self.do_alloc(cluster_spec)
+        self.max_used_nodes = max(self.max_used_nodes, len(self.used()))
+        return allocated
+
+    def do_alloc(self, cluster_spec):
+        """
+        Subclasses should implement actual allocation here.
+
+        :param cluster_spec:                    A ClusterSpec describing the nodes to be allocated.
+        :throws InsufficientResources:          If the nodes cannot be allocated.
+        :return:                                Allocated nodes spec
         """
         raise NotImplementedError
 
@@ -80,6 +96,9 @@ class Cluster(object):
         Return a ClusterSpec object describing the currently in use nodes.
         """
         raise NotImplementedError
+
+    def max_used(self):
+        return self.max_used_nodes
 
     def all(self):
         """

--- a/ducktape/cluster/finite_subcluster.py
+++ b/ducktape/cluster/finite_subcluster.py
@@ -22,11 +22,12 @@ class FiniteSubcluster(Cluster):
     """
 
     def __init__(self, nodes):
+        super(FiniteSubcluster, self).__init__()
         self.nodes = nodes
         self._available_nodes = NodeContainer(nodes)
         self._in_use_nodes = NodeContainer()
 
-    def alloc(self, cluster_spec):
+    def do_alloc(self, cluster_spec):
         allocated = self._available_nodes.remove_spec(cluster_spec)
         self._in_use_nodes.add_nodes(allocated)
         return allocated

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -110,7 +110,7 @@ class JsonCluster(Cluster):
             return LinuxRemoteAccount(ssh_config=ssh_config,
                                       externally_routable_ip=externally_routable_ip)
 
-    def alloc(self, cluster_spec):
+    def do_alloc(self, cluster_spec):
         allocated_accounts = self._available_accounts.remove_spec(cluster_spec)
         allocated_nodes = []
         for account in allocated_accounts:

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -34,7 +34,7 @@ class LocalhostCluster(Cluster):
             self._available_nodes.add_node(ClusterNode(LinuxRemoteAccount(ssh_config)))
         self._in_use_nodes = NodeContainer()
 
-    def alloc(self, cluster_spec):
+    def do_alloc(self, cluster_spec):
         allocated = self._available_nodes.remove_spec(cluster_spec)
         self._in_use_nodes.add_nodes(allocated)
         return allocated

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -27,6 +27,7 @@ class LocalhostCluster(Cluster):
     """
 
     def __init__(self, *args, **kwargs):
+        super(LocalhostCluster, self).__init__()
         num_nodes = kwargs.get("num_nodes", 1000)
         self._available_nodes = NodeContainer()
         for i in range(num_nodes):

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -162,6 +162,7 @@ class RunnerClient(object):
                 start_time,
                 stop_time)
 
+            self._check_cluster_utilization()
             self.log(logging.INFO, "Summary: %s" % str(result.summary))
             self.log(logging.INFO, "Data: %s" % str(result.data))
 
@@ -174,6 +175,12 @@ class RunnerClient(object):
             self.test_context.close()
             self.test_context = None
             self.test = None
+
+    def _check_cluster_utilization(self):
+        max_used = self.cluster.max_used()
+        total = len(self.cluster.all())
+        if max_used < total:
+            self.log(logging.WARN, "Test requested %d nodes, used only %d" % (total, max_used))
 
     def setup_test(self):
         """start services etc"""

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -87,6 +87,27 @@ class GenericService(Service):
         node.account.remove(self.worker_scratch_dir, allow_fail=True)
 
 
+class UnderUtilizedTest(Test):
+
+    def setup(self):
+        self.service = GenericService(self.test_context, 1)
+
+    @cluster(num_nodes=3)
+    def under_utilized_test(self):
+        # setup() creates a service instance, which calls alloc() for one node
+        assert self.test_context.cluster.max_used() == 1
+        assert len(self.test_context.cluster.used()) == 1
+
+        self.another_service = GenericService(self.test_context, 1)
+        assert len(self.test_context.cluster.used()) == 2
+        assert self.test_context.cluster.max_used() == 2
+
+        self.service.stop()
+        self.service.free()
+        assert len(self.test_context.cluster.used()) == 1
+        assert self.test_context.cluster.max_used() == 2
+
+
 class FileSystemTest(Test):
     """
     Note that in an attempt to isolate the file system methods, validation should be done with ssh/shell commands.

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -45,7 +45,7 @@ class FakeCluster(Cluster):
             self._available_nodes.add_node(FakeClusterNode())
         self._in_use_nodes = NodeContainer()
 
-    def alloc(self, cluster_spec):
+    def do_alloc(self, cluster_spec):
         allocated = self._available_nodes.remove_spec(cluster_spec)
         self._in_use_nodes.add_nodes(allocated)
         return allocated

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -40,6 +40,7 @@ class FakeCluster(Cluster):
     """A cluster class with counters, but no actual node objects"""
 
     def __init__(self, num_nodes):
+        super(FakeCluster, self).__init__()
         self._available_nodes = NodeContainer()
         for i in range(0, num_nodes):
             self._available_nodes.add_node(FakeClusterNode())


### PR DESCRIPTION
This should allow us to monitor sub-optimal usage of cluster resources.