### PR TITLE
Fix 'defaults' mark to preserve cluster metadata

### DIFF
--- a/ducktape/mark/_mark.py
+++ b/ducktape/mark/_mark.py
@@ -159,10 +159,12 @@ class Defaults(Mark):
                 for injected_args in cartesian_product_dict(
                         {arg: self.injected_args[arg] for arg in self.injected_args if arg not in ctx.injected_args}):
                     injected_args.update(ctx.injected_args)
-                    if ctx.cluster_use_metadata:
-                        seed_context.cluster_use_metadata = ctx.cluster_use_metadata
                     injected_fun = _inject(**injected_args)(seed_context.function)
-                    new_context_list.insert(0, seed_context.copy(function=injected_fun, injected_args=injected_args))
+                    new_context = seed_context.copy(
+                        function=injected_fun,
+                        injected_args=injected_args,
+                        cluster_use_metadata=ctx.cluster_use_metadata)
+                    new_context_list.insert(0, new_context)
         else:
             for injected_args in cartesian_product_dict(self.injected_args):
                 injected_fun = _inject(**injected_args)(seed_context.function)

--- a/ducktape/mark/_mark.py
+++ b/ducktape/mark/_mark.py
@@ -159,6 +159,8 @@ class Defaults(Mark):
                 for injected_args in cartesian_product_dict(
                         {arg: self.injected_args[arg] for arg in self.injected_args if arg not in ctx.injected_args}):
                     injected_args.update(ctx.injected_args)
+                    if ctx.cluster_use_metadata:
+                        seed_context.cluster_use_metadata = ctx.cluster_use_metadata
                     injected_fun = _inject(**injected_args)(seed_context.function)
                     new_context_list.insert(0, seed_context.copy(function=injected_fun, injected_args=injected_args))
         else:

--- a/tests/loader/resources/loader_test_directory/test_decorated.py
+++ b/tests/loader/resources/loader_test_directory/test_decorated.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 from ducktape.tests.test import Test
+from ducktape.mark.resource import cluster
 from ducktape.mark import matrix
 from ducktape.mark import parametrize
+from ducktape.mark import defaults
+
 
 NUM_TESTS = 15
 
@@ -43,4 +46,15 @@ class TestParametrized(Test):
     @parametrize(x="abc", y=[])
     def test_thing(self, x, y):
         """2 tests"""
+        pass
+
+class TestStackedDefaultClusterMatrixParametrized(Test):
+    @cluster(num_nodes=5)
+    @defaults(y=[1])
+    # @cluster(num_nodes=3)
+    @parametrize(x=[1])
+    @cluster(num_nodes=7)
+    @matrix(x=[4])
+    def test_thing(self, x, y):
+        print("works!!!")
         pass

--- a/tests/loader/resources/loader_test_directory/test_decorated.py
+++ b/tests/loader/resources/loader_test_directory/test_decorated.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 from ducktape.tests.test import Test
-from ducktape.mark.resource import cluster
 from ducktape.mark import matrix
 from ducktape.mark import parametrize
-from ducktape.mark import defaults
-
 
 NUM_TESTS = 15
 
@@ -46,15 +43,4 @@ class TestParametrized(Test):
     @parametrize(x="abc", y=[])
     def test_thing(self, x, y):
         """2 tests"""
-        pass
-
-class TestStackedDefaultClusterMatrixParametrized(Test):
-    @cluster(num_nodes=5)
-    @defaults(y=[1])
-    # @cluster(num_nodes=3)
-    @parametrize(x=[1])
-    @cluster(num_nodes=7)
-    @matrix(x=[4])
-    def test_thing(self, x, y):
-        print("works!!!")
         pass

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from ducktape.mark import parametrize, matrix, ignore
+from ducktape.mark import parametrize, matrix, ignore, defaults
 from ducktape.mark.mark_expander import MarkedFunctionExpander
 from ducktape.mark.resource import cluster
 from ducktape.cluster.cluster_spec import ClusterSpec
@@ -93,6 +93,35 @@ class CheckClusterUseAnnotation(object):
 
         with pytest.raises(AssertionError):
             MarkedFunctionExpander(function=f).expand()
+
+    def check_with_nodes_default_parametrize_matrix(self):
+        default_num_nodes = 5
+        parametrize_num_nodes = 3
+        matrix_num_nodes = 7
+
+        @cluster(num_nodes=default_num_nodes)
+        @defaults(y=[5])
+        @parametrize(x=100, y=200)
+        @cluster(num_nodes=parametrize_num_nodes)
+        @parametrize(x=10, y=20)
+        @parametrize(x=30, y=40)
+        @cluster(num_nodes=matrix_num_nodes)
+        @matrix(x=[1, 2])
+        def f(x, y):
+            return x, y
+
+        test_context_list = MarkedFunctionExpander(function=f).expand()
+        assert len(test_context_list) == 5
+        # {'x': 1, 'y': 5} -> using matrix with matrix_num_nodes
+        assert test_context_list[0].expected_num_nodes == matrix_num_nodes
+        # {'x': 2, 'y': 5} -> using matrix with matrix_num_nodes
+        assert test_context_list[1].expected_num_nodes == matrix_num_nodes
+        # {'x': 30, 'y': 40} -> using parametrize with cluster parametrize_num_nodes
+        assert test_context_list[2].expected_num_nodes == parametrize_num_nodes
+        # {'x': 10, 'y': 20} -> using parametrize with cluster parametrize_num_nodes
+        assert test_context_list[3].expected_num_nodes == parametrize_num_nodes
+        # {'x': 100, 'y': 200} -> using parametrize with default_num_nodes
+        assert test_context_list[4].expected_num_nodes == default_num_nodes
 
     def check_no_override(self):
         """ cluster use metadata should apply to all test cases physically below it, except for those which already


### PR DESCRIPTION
**Existing Implementation:**

If the `@default` mark is specified, and if there is a `@cluster` with `num_nodes` before default, this is overridden in cases when matrix or parametrized has `@cluster` mark. 
Example:
```
  @cluster(num_nodes=5)
  @defaults(y=[5])
  @parametrize(x=100, y=200)
  @cluster(num_nodes=3)
  @parametrize(x=10, y=20)
  @parametrize(x=30, y=40)
  @cluster(num_nodes=7)
  @matrix(x=[1, 2])
  def test_thing(self, x, y):
      pass
```
since we have default num_nodes as 5, even though matrix and parameterize have 7 and 3 respectively, it's ignored and hence all 5 tests above will request 5 nodes instead.

**Modified Implementation:**

This PR fixes the above issue and the output for the above scenario after fix would be:

```
 {'x': 1, 'y': 5} -> using matrix --> uses  7 nodes
 {'x': 2, 'y': 5} -> using matrix --> uses 7 nodes
 {'x': 30, 'y': 40} -> using parametrize --> uses 3 nodes
 {'x': 10, 'y': 20} -> using parametrize --> uses 3 nodes
 {'x': 100, 'y': 200} -> using parametrize (default) --> uses 5 nodes
```