### PR TITLE
Fix failure to load if discovery symbol characters in json

### DIFF
--- a/ducktape/tests/loader.py
+++ b/ducktape/tests/loader.py
@@ -230,34 +230,20 @@ class TestLoader(object):
             "path/to/test_file.py" -> ("path/to/test_file.py", "", "")
             "path/to/test_file.py::ClassName.method" -> ("path/to/test_file.py", "ClassName", "method")
         """
+        def divide_by_symbol(ds, symbol):
+            if symbol not in ds:
+                return ds, ""
+            idx = ds.index(symbol)
+            return ds[:idx], ds[idx + len(symbol):]
+
         self.logger.debug('Trying to parse discovery symbol {}'.format(discovery_symbol))
         if base_dir:
             discovery_symbol = os.path.join(base_dir, discovery_symbol)
         if discovery_symbol.find("::") >= 0:
-            parts = discovery_symbol.split("::")
-            if len(parts) == 1:
-                path, cls_name = parts[0], ""
-            elif len(parts) == 2:
-                path, cls_name = parts
-            else:
-                raise LoaderException("Invalid discovery symbol: " + discovery_symbol)
-
+            path, cls_name = divide_by_symbol(discovery_symbol, "::")
             # If the part after :: contains a dot, use it to split into class + method
-            parts = cls_name.split('.')
-            if len(parts) == 1:
-                method_name = ""
-            elif len(parts) == 2:
-                cls_name, method_name = parts
-            else:
-                raise LoaderException("Invalid discovery symbol: " + discovery_symbol)
-
-            parts = method_name.split('@')
-            if len(parts) == 1:
-                injected_args_str = None
-            elif len(parts) == 2:
-                method_name, injected_args_str = parts
-            else:
-                raise LoaderException("Invalid discovery symbol: " + discovery_symbol)
+            cls_name, method_name = divide_by_symbol(cls_name, ".")
+            method_name, injected_args_str = divide_by_symbol(method_name, "@")
 
             if injected_args_str:
                 if self.injected_args:

--- a/ducktape/tests/loader.py
+++ b/ducktape/tests/loader.py
@@ -233,8 +233,7 @@ class TestLoader(object):
         def divide_by_symbol(ds, symbol):
             if symbol not in ds:
                 return ds, ""
-            idx = ds.index(symbol)
-            return ds[:idx], ds[idx + len(symbol):]
+            return ds.split(symbol, maxsplit=1)
 
         self.logger.debug('Trying to parse discovery symbol {}'.format(discovery_symbol))
         if base_dir:

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -324,6 +324,15 @@ class CheckTestLoader(object):
         assert len(tests) == 1
         assert tests[0].injected_args == {'x': 1, 'y': 'test '}
 
+    def check_test_loader_with_params_special_chars(self):
+        loader = TestLoader(self.SESSION_CONTEXT, logger=Mock())
+        included = [os.path.join(discover_dir(), r'test_decorated.py::TestParametrizdeSpecial.test_special_characters_params@{"version": "6.1.0", "chars": "!@#$%^&*()_+::.,/? \"{}\\"}')]
+        tests = loader.load(included)
+        # TestMatrix contains a single parametrized method. Since we only provide a single set of params, we should
+        # end up with a single context
+        assert len(tests) == 1
+        assert tests[0].injected_args == {'version': '6.1.0', 'chars': '!@#$%^&*()_+::.,/? \"{}\\'}
+
     def check_test_loader_with_multiple_matrix_params(self):
         loader = TestLoader(self.SESSION_CONTEXT, logger=Mock())
         params = '[{"x": 1,"y": "test "}, {"x": 2,"y": "I\'m"}]'
@@ -366,7 +375,7 @@ class CheckTestLoader(object):
 
         file = os.path.join(discover_dir(), "test_decorated.py")
         tests = loader.load([file])
-        assert len(tests) == 5
+        assert len(tests) == 6
 
         for t in tests:
             assert t.injected_args == injected_args
@@ -412,7 +421,7 @@ class CheckTestLoader(object):
         # test_decorated.py contains 5 test methods total
         # we exclude 1 class with 1 method so should be 4
         # exclusion shouldn't care about injected args
-        assert len(tests) == 4
+        assert len(tests) == 5
 
         for t in tests:
             assert t.injected_args == injected_args
@@ -451,14 +460,14 @@ class CheckTestLoader(object):
 
         file = os.path.join(discover_dir(), "test_decorated.py")
 
-        # The test file contains 17 tests. With 4 subsets, first subset should have an "extra"
+        # The test file contains 18 tests. With 4 subsets, first two subset should have an "extra"
         loader = TestLoader(self.SESSION_CONTEXT, logger=Mock(), subset=0, subsets=4)
         tests = loader.load([file])
         assert len(tests) == 5
 
         loader = TestLoader(self.SESSION_CONTEXT, logger=Mock(), subset=1, subsets=4)
         tests = loader.load([file])
-        assert len(tests) == 4
+        assert len(tests) == 5
 
         loader = TestLoader(self.SESSION_CONTEXT, logger=Mock(), subset=2, subsets=4)
         tests = loader.load([file])

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -327,7 +327,8 @@ class CheckTestLoader(object):
     def check_test_loader_with_params_special_chars(self):
         loader = TestLoader(self.SESSION_CONTEXT, logger=Mock())
         included = [os.path.join(discover_dir(
-        ), r'test_decorated.py::TestParametrizdeSpecial.test_special_characters_params@{"version": "6.1.0", "chars": "!@#$%^&*()_+::.,/? \"{}\\"}')]
+        ), r'test_decorated.py::TestParametrizdeSpecial.test_special_characters_params'
+           r'@{"version": "6.1.0", "chars": "!@#$%^&*()_+::.,/? \"{}\\"}')]
         tests = loader.load(included)
         # TestMatrix contains a single parametrized method. Since we only provide a single set of params, we should
         # end up with a single context

--- a/tests/loader/check_loader.py
+++ b/tests/loader/check_loader.py
@@ -326,7 +326,8 @@ class CheckTestLoader(object):
 
     def check_test_loader_with_params_special_chars(self):
         loader = TestLoader(self.SESSION_CONTEXT, logger=Mock())
-        included = [os.path.join(discover_dir(), r'test_decorated.py::TestParametrizdeSpecial.test_special_characters_params@{"version": "6.1.0", "chars": "!@#$%^&*()_+::.,/? \"{}\\"}')]
+        included = [os.path.join(discover_dir(
+        ), r'test_decorated.py::TestParametrizdeSpecial.test_special_characters_params@{"version": "6.1.0", "chars": "!@#$%^&*()_+::.,/? \"{}\\"}')]
         tests = loader.load(included)
         # TestMatrix contains a single parametrized method. Since we only provide a single set of params, we should
         # end up with a single context

--- a/tests/loader/resources/loader_test_directory/test_decorated.py
+++ b/tests/loader/resources/loader_test_directory/test_decorated.py
@@ -16,7 +16,7 @@ from ducktape.tests.test import Test
 from ducktape.mark import matrix
 from ducktape.mark import parametrize
 
-NUM_TESTS = 17
+NUM_TESTS = 18
 
 
 class TestMatrix(Test):
@@ -45,6 +45,11 @@ class TestParametrized(Test):
         """2 tests"""
         pass
 
+class TestParametrizdeSpecial(Test):
+    @parametrize(version="6.1.0", chars="!@#$%^&*()_+::.,/? \"{}\\")
+    def test_special_characters_params(self, version, chars):
+        """1 tests"""
+        pass
 
 class TestObjectParameters(Test):
     @parametrize(d={'a': 'A'}, lst=['whatever'])

--- a/tests/loader/resources/loader_test_directory/test_decorated.py
+++ b/tests/loader/resources/loader_test_directory/test_decorated.py
@@ -45,11 +45,13 @@ class TestParametrized(Test):
         """2 tests"""
         pass
 
+
 class TestParametrizdeSpecial(Test):
     @parametrize(version="6.1.0", chars="!@#$%^&*()_+::.,/? \"{}\\")
     def test_special_characters_params(self, version, chars):
         """1 tests"""
         pass
+
 
 class TestObjectParameters(Test):
     @parametrize(d={'a': 'A'}, lst=['whatever'])


### PR DESCRIPTION
Currently in ducktape if you try to load a test with characters used in the loading process in your json, the loader will fail to discover tests.
ex:
`dummy_test.py::DummyTest.test@{'version':'1.0.0.'}` - fails to load with an `Invalid discovery symbol:` loader error

to fix this, I manually split by the rightmost occurrence of the split character, and allow the failures to occur when loading json.