### PR TITLE
Fail test option when node utilization isn't optimal

### DIFF
--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -72,6 +72,8 @@ def create_ducktape_parser():
                              "instead of by number of tests.")
     parser.add_argument("--sample", action="store", type=int,
                         help="The size of a random test sample to run")
+    parser.add_argument("--fail-bad-cluster-utilization", action="store_true",
+                        help="Fail a test if the cluster node utilization does not match the cluster node usage.")
     return parser
 
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -232,7 +232,8 @@ class TestRunner(object):
                 current_test_counter,
                 TestContext.logger_name(test_context, current_test_counter),
                 TestContext.results_dir(test_context, current_test_counter),
-                self.session_context.debug
+                self.session_context.debug,
+                self.session_context.fail_bad_cluster_utilization
             ])
 
         self._client_procs[test_key] = proc

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -180,10 +180,10 @@ class RunnerClient(object):
             self.test = None
 
     def _check_cluster_utilization(self, result, summary):
-        """Pass through results and summary and modify the values if
-        the number of nodes used by a test is less than the number of nodes
-        requested by a test.  Will also print a warning if the test passes and
-        the node utilization doesn't match.
+        """Checks if the number of nodes used by a test is less than the number of
+        nodes requested by the test. If this is the case and we wish to fail
+        on bad cluster utilization, the result value is failed. Will also print
+        a warning if the test passes and the node utilization doesn't match.
         """
         max_used = self.cluster.max_used()
         total = len(self.cluster.all())

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -179,6 +179,11 @@ class RunnerClient(object):
             self.test = None
 
     def _check_cluster_utilization(self, result, summary):
+        """Pass through results and summary and modify the values if 
+        the number of nodes used by a test is less than the number of nodes
+        requested by a test.  Will also print a warning if the test passes and 
+        the node utilization doesn't match.
+        """
         max_used = self.cluster.max_used()
         total = len(self.cluster.all())
         if max_used < total:

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -38,7 +38,8 @@ def run_client(*args, **kwargs):
 class RunnerClient(object):
     """Run a single test"""
 
-    def __init__(self, server_hostname, server_port, test_id, test_index, logger_name, log_dir, debug, fail_bad_cluster_utilization):
+    def __init__(self, server_hostname, server_port, test_id,
+                 test_index, logger_name, log_dir, debug, fail_bad_cluster_utilization):
         signal.signal(signal.SIGTERM, self._sigterm_handler)  # register a SIGTERM handler
 
         self.serde = SerDe()
@@ -179,9 +180,9 @@ class RunnerClient(object):
             self.test = None
 
     def _check_cluster_utilization(self, result, summary):
-        """Pass through results and summary and modify the values if 
+        """Pass through results and summary and modify the values if
         the number of nodes used by a test is less than the number of nodes
-        requested by a test.  Will also print a warning if the test passes and 
+        requested by a test.  Will also print a warning if the test passes and
         the node utilization doesn't match.
         """
         max_used = self.cluster.max_used()

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -37,6 +37,7 @@ class SessionContext(object):
         self.no_teardown = kwargs.get("no_teardown", False)
         self.max_parallel = kwargs.get("max_parallel", 1)
         self.default_expected_num_nodes = kwargs.get("default_num_nodes", None)
+        self.fail_bad_cluster_utilization = kwargs.get("fail_bad_cluster_utilization")
         self._globals = kwargs.get("globals")
 
     @property

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -26,7 +26,7 @@ from tests.ducktape_mock import FakeCluster
 import tests.ducktape_mock
 from tests.runner.resources.test_fails_to_init import FailsToInitTest
 from tests.runner.resources.test_fails_to_init_in_setup import FailsToInitInSetupTest
-from .resources.test_thingy import TestThingy
+from .resources.test_thingy import ClusterTestThingy, TestThingy
 from .resources.test_failing_tests import FailingTest
 from ducktape.tests.reporter import JUnitReporter
 
@@ -187,3 +187,22 @@ class CheckRunner(object):
         assert results.num_failed == 2
         assert results.num_passed == 0
         assert results.num_ignored == 2
+
+    def check_run_failure_with_bad_cluster_allocation(self):
+        """Check expected behavior when running a single test."""
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context(
+            fail_bad_cluster_utilization="fail_bad_cluster_utilization")
+
+        test_methods = [ClusterTestThingy.test_bad_num_nodes, ClusterTestThingy.test_good_num_nodes]
+        ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=ClusterTestThingy,
+                                   test_methods=test_methods, cluster=mock_cluster,
+                                   session_context=session_context)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+
+        results = runner.run_all_tests()
+
+        assert len(results) == 2
+        assert results.num_failed == 1
+        assert results.num_passed == 1
+        assert results.num_ignored == 0

--- a/tests/runner/resources/test_thingy.py
+++ b/tests/runner/resources/test_thingy.py
@@ -15,6 +15,7 @@
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.tests.test import Test
 from ducktape.mark import ignore, parametrize
+from ducktape.mark.resource import cluster
 
 
 class TestThingy(Test):
@@ -38,3 +39,15 @@ class TestThingy(Test):
 
     def test_failure(self):
         raise Exception("This failed")
+
+
+class ClusterTestThingy(Test):
+    """Fake ducktape test class"""
+
+    @cluster(num_nodes=10)
+    def test_bad_num_nodes(self):
+        pass
+
+    @cluster(num_nodes=0)
+    def test_good_num_nodes(self):
+        pass


### PR DESCRIPTION
This PR allows for users to specify that improper node utilization causes a failure.  Currently if you define a cluster that requests more nodes than a test actually uses ducktape logs a warning specifying the number of nodes miss-match.  This PR allows you to specify the `--fail-bad-cluster-utilization` when running tests, which fails the test if the node utilization is miss matched.