### PR TITLE
add timeout parameter and set it to 0mq socket

### DIFF
--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -75,7 +75,7 @@ def create_ducktape_parser():
     parser.add_argument("--fail-bad-cluster-utilization", action="store_true",
                         help="Fail a test if the cluster node utilization does not match the cluster node usage.")
     parser.add_argument("--test-runner-timeout", action="store", type=int, default=1800000,
-                        help="Amount of time in milliseconds between test communicating between the test runner" \
+                        help="Amount of time in milliseconds between test communicating between the test runner"
                              " before a timeout error occurs. Default is 30 minutes")
     return parser
 

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -74,6 +74,9 @@ def create_ducktape_parser():
                         help="The size of a random test sample to run")
     parser.add_argument("--fail-bad-cluster-utilization", action="store_true",
                         help="Fail a test if the cluster node utilization does not match the cluster node usage.")
+    parser.add_argument("--test-runner-timeout", action="store", type=int, default=1800000,
+                        help="Amount of time in milliseconds between test communicating between the test runner" \
+                             " before a timeout error occurs. Default is 30 minutes")
     return parser
 
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -63,7 +63,7 @@ class Receiver(object):
         self.socket.RCVTIMEO = timeout
         try:
             message = self.socket.recv()
-        except zmq.Again as e:
+        except zmq.Again:
             raise TimeoutError("runner client unresponsive")
         return self.serde.deserialize(message)
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -64,7 +64,7 @@ class Receiver(object):
         try:
             message = self.socket.recv()
         except zmq.Again as e:
-            raise TimeoutError("runner client unresponsive") from e
+            raise TimeoutError("runner client unresponsive")
         return self.serde.deserialize(message)
 
     def send(self, event):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -59,7 +59,10 @@ class Receiver(object):
     def recv(self, timeout=3600000):
         # default timeout of 1 hours
         self.socket.RCVTIMEO = timeout
-        message = self.socket.recv()
+        try:
+            message = self.socket.recv()
+        except zmq.Again as e:
+            raise TimeoutError("runner client unresponsive") from e
         return self.serde.deserialize(message)
 
     def send(self, event):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -57,7 +57,9 @@ class Receiver(object):
                                                     max_tries=2 * (self.max_port + 1 - self.min_port))
 
     def recv(self, timeout=1800000):
-        # default timeout of 30 minutes
+        if timeout is None:
+            # use default value of 1800000 or 30 minutes
+            timeout = 1800000
         self.socket.RCVTIMEO = timeout
         try:
             message = self.socket.recv()

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -56,8 +56,8 @@ class Receiver(object):
         self.port = self.socket.bind_to_random_port(addr="tcp://*", min_port=self.min_port, max_port=self.max_port + 1,
                                                     max_tries=2 * (self.max_port + 1 - self.min_port))
 
-    def recv(self, timeout=3600000):
-        # default timeout of 1 hours
+    def recv(self, timeout=1800000):
+        # default timeout of 30 minutes
         self.socket.RCVTIMEO = timeout
         try:
             message = self.socket.recv()
@@ -197,7 +197,7 @@ class TestRunner(object):
 
                 if self._expect_client_requests:
                     try:
-                        event = self.receiver.recv()
+                        event = self.receiver.recv(timeout=self.session_context.test_runner_timeout)
                         self._handle(event)
                     except Exception as e:
                         err_str = "Exception receiving message: %s: %s" % (str(type(e)), str(e))

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -56,7 +56,9 @@ class Receiver(object):
         self.port = self.socket.bind_to_random_port(addr="tcp://*", min_port=self.min_port, max_port=self.max_port + 1,
                                                     max_tries=2 * (self.max_port + 1 - self.min_port))
 
-    def recv(self):
+    def recv(self, timeout=1200000):
+        # default timeout of 2 hours
+        self.socket.RCVTIMEO = timeout
         message = self.socket.recv()
         return self.serde.deserialize(message)
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -34,6 +34,7 @@ from ducktape.cluster.finite_subcluster import FiniteSubcluster
 from ducktape.tests.scheduler import TestScheduler
 from ducktape.tests.result import FAIL, TestResult
 from ducktape.tests.reporter import SimpleFileSummaryReporter, HTMLSummaryReporter, JSONReporter
+from ducktape.errors import TimeoutError
 
 
 class Receiver(object):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -56,8 +56,8 @@ class Receiver(object):
         self.port = self.socket.bind_to_random_port(addr="tcp://*", min_port=self.min_port, max_port=self.max_port + 1,
                                                     max_tries=2 * (self.max_port + 1 - self.min_port))
 
-    def recv(self, timeout=1200000):
-        # default timeout of 2 hours
+    def recv(self, timeout=3600000):
+        # default timeout of 1 hours
         self.socket.RCVTIMEO = timeout
         message = self.socket.recv()
         return self.serde.deserialize(message)

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -38,6 +38,7 @@ class SessionContext(object):
         self.max_parallel = kwargs.get("max_parallel", 1)
         self.default_expected_num_nodes = kwargs.get("default_num_nodes", None)
         self.fail_bad_cluster_utilization = kwargs.get("fail_bad_cluster_utilization")
+        self.test_runner_timeout = kwargs.get("test_runner_timeout")
         self._globals = kwargs.get("globals")
 
     @property

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -344,8 +344,8 @@ class TestContext(object):
         return {
             "directory": os.path.dirname(self.file),
             "file_name": os.path.basename(self.file),
-            "cls_name": self.cls.__name__,
-            "method_name": self.function.__name__,
+            "cls_name": self.cls_name,
+            "method_name": self.function_name,
             "injected_args": self.injected_args
         }
 

--- a/tests/runner/check_sender_receiver.py
+++ b/tests/runner/check_sender_receiver.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.cluster.localhost import LocalhostCluster
+from tests.ducktape_mock import test_context, session_context
+
+import logging
+import pytest
+from ducktape.tests.runner_client import Sender
+from ducktape.tests.runner import Receiver
+from ducktape.tests.event import ClientEventFactory, EventResponseFactory
+
+
+import multiprocessing as mp
+import os
+
+
+class CheckSenderReceiver(object):
+    def ready_response(self, client_id):
+        sender_event_factory = ClientEventFactory("test_1", 0, client_id)
+        sender = Sender(server_host='localhost', server_port=8888,
+                        message_supplier=sender_event_factory, logger=logging)
+        sender.send(sender_event_factory.ready())
+
+    def check_simple_messaging(self):
+        s_context = session_context()
+        cluster = LocalhostCluster(num_nodes=1000)
+        t_context = test_context(s_context, cluster)
+
+        client_id = "test-runner-{}-{}".format(os.getpid(), id(self))
+        receiver_response_factory = EventResponseFactory()
+
+        receiver = Receiver(8888, 8888)
+        receiver.start()
+
+        try:
+            p = mp.Process(target=self.ready_response, args=(client_id,))
+            p.start()
+
+            event = receiver.recv(timeout=10000)
+            assert event["event_type"] == ClientEventFactory.READY
+            logging.info('replying to client')
+            receiver.send(receiver_response_factory.ready(event, s_context, t_context, cluster))
+        finally:
+            p.join()
+
+    def check_timeout(self):
+        client_id = "test-runner-{}-{}".format(os.getpid(), id(self))
+
+        receiver = Receiver(8888, 8888)
+        receiver.start()
+        try:
+            p = mp.Process(target=self.ready_response, args=(client_id,))
+            p.start()
+            with pytest.raises(TimeoutError):
+                receiver.recv(timeout=0)
+        finally:
+            p.join()

--- a/tests/runner/check_sender_receiver.py
+++ b/tests/runner/check_sender_receiver.py
@@ -27,9 +27,9 @@ import os
 
 
 class CheckSenderReceiver(object):
-    def ready_response(self, client_id):
+    def ready_response(self, client_id, port):
         sender_event_factory = ClientEventFactory("test_1", 0, client_id)
-        sender = Sender(server_host='localhost', server_port=8888,
+        sender = Sender(server_host='localhost', server_port=port,
                         message_supplier=sender_event_factory, logger=logging)
         sender.send(sender_event_factory.ready())
 
@@ -41,11 +41,12 @@ class CheckSenderReceiver(object):
         client_id = "test-runner-{}-{}".format(os.getpid(), id(self))
         receiver_response_factory = EventResponseFactory()
 
-        receiver = Receiver(8888, 8888)
+        receiver = Receiver(5556, 5656)
         receiver.start()
+        port = receiver.port
 
         try:
-            p = mp.Process(target=self.ready_response, args=(client_id,))
+            p = mp.Process(target=self.ready_response, args=(client_id, port))
             p.start()
 
             event = receiver.recv(timeout=10000)
@@ -58,10 +59,12 @@ class CheckSenderReceiver(object):
     def check_timeout(self):
         client_id = "test-runner-{}-{}".format(os.getpid(), id(self))
 
-        receiver = Receiver(8888, 8888)
+        receiver = Receiver(5556, 5656)
         receiver.start()
+        port = receiver.port
+
         try:
-            p = mp.Process(target=self.ready_response, args=(client_id,))
+            p = mp.Process(target=self.ready_response, args=(client_id, port))
             p.start()
             with pytest.raises(TimeoutError):
                 receiver.recv(timeout=0)

--- a/tests/runner/check_sender_receiver.py
+++ b/tests/runner/check_sender_receiver.py
@@ -20,7 +20,7 @@ import pytest
 from ducktape.tests.runner_client import Sender
 from ducktape.tests.runner import Receiver
 from ducktape.tests.event import ClientEventFactory, EventResponseFactory
-
+from ducktape.errors import TimeoutError
 
 import multiprocessing as mp
 import os


### PR DESCRIPTION
add a timeout to test runners recv method, so if a test fails to send a message to the receiver, the receiver will throw a timeout error.