### PR TITLE
Add SSH failure callbacks

### DIFF
--- a/docs/debug_tests.rst
+++ b/docs/debug_tests.rst
@@ -97,3 +97,13 @@ Tools for Managing Logs
 =======================
 
 Analyzing and matching up logs from a distributed service could be time consuming. There are many good tools for working with logs. Examples include http://lnav.org/, http://list.xmodulo.com/multitail.html, and http://glogg.bonnefon.org/.
+
+Validating Ssh Issues
+=======================
+
+Ducktape supports running custom validators when an ssh error occurs, allowing you to run your own validation against a host.
+this is done simply by running ducktape with the `--ssh-checker-function`, followed by the module path to your function, so for instance::
+    
+    ducktape my-test.py --ssh-checker-function my.module.validator.validate_ssh
+
+this function will take in the ssh error raised as its first argument, and the remote account object as its second.

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -90,8 +90,9 @@ class JsonCluster(Cluster):
                     "Cluster json has a node without a ssh_config field: %s\n Cluster json: %s" % (ninfo, cluster_json)
 
                 ssh_config = RemoteAccountSSHConfig(**ninfo.get("ssh_config", {}))
-                remote_account = JsonCluster.make_remote_account(ssh_config, ninfo.get("externally_routable_ip"),
-                                                         ssh_exception_checks=kwargs.get("ssh_exception_checks"))
+                remote_account = \
+                    JsonCluster.make_remote_account(ssh_config, ninfo.get("externally_routable_ip"),
+                                                    ssh_exception_checks=kwargs.get("ssh_exception_checks"))
                 if remote_account.externally_routable_ip is None:
                     remote_account.externally_routable_ip = self._externally_routable_ip(remote_account)
                 self._available_accounts.add_node(remote_account)

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -90,7 +90,8 @@ class JsonCluster(Cluster):
                     "Cluster json has a node without a ssh_config field: %s\n Cluster json: %s" % (ninfo, cluster_json)
 
                 ssh_config = RemoteAccountSSHConfig(**ninfo.get("ssh_config", {}))
-                remote_account = JsonCluster.make_remote_account(ssh_config, ninfo.get("externally_routable_ip"))
+                remote_account = JsonCluster.make_remote_account(ssh_config, ninfo.get("externally_routable_ip"),
+                                                                 ssh_exception_checks=kwargs.get("ssh_exception_checks"))
                 if remote_account.externally_routable_ip is None:
                     remote_account.externally_routable_ip = self._externally_routable_ip(remote_account)
                 self._available_accounts.add_node(remote_account)
@@ -100,15 +101,13 @@ class JsonCluster(Cluster):
         self._id_supplier = 0
 
     @staticmethod
-    def make_remote_account(ssh_config, externally_routable_ip=None):
+    def make_remote_account(ssh_config, *args, **kwargs):
         """Factory function for creating the correct RemoteAccount implementation."""
 
         if ssh_config.host and WINDOWS in ssh_config.host:
-            return WindowsRemoteAccount(ssh_config=ssh_config,
-                                        externally_routable_ip=externally_routable_ip)
+            return WindowsRemoteAccount(ssh_config, *args, **kwargs)
         else:
-            return LinuxRemoteAccount(ssh_config=ssh_config,
-                                      externally_routable_ip=externally_routable_ip)
+            return LinuxRemoteAccount(ssh_config, *args, **kwargs)
 
     def do_alloc(self, cluster_spec):
         allocated_accounts = self._available_accounts.remove_spec(cluster_spec)

--- a/ducktape/cluster/json.py
+++ b/ducktape/cluster/json.py
@@ -91,7 +91,7 @@ class JsonCluster(Cluster):
 
                 ssh_config = RemoteAccountSSHConfig(**ninfo.get("ssh_config", {}))
                 remote_account = JsonCluster.make_remote_account(ssh_config, ninfo.get("externally_routable_ip"),
-                                                                 ssh_exception_checks=kwargs.get("ssh_exception_checks"))
+                                                         ssh_exception_checks=kwargs.get("ssh_exception_checks"))
                 if remote_account.externally_routable_ip is None:
                     remote_account.externally_routable_ip = self._externally_routable_ip(remote_account)
                 self._available_accounts.add_node(remote_account)

--- a/ducktape/cluster/linux_remoteaccount.py
+++ b/ducktape/cluster/linux_remoteaccount.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from ducktape.cluster.cluster_spec import LINUX
 from ducktape.cluster.remoteaccount import RemoteAccount
 
 
 class LinuxRemoteAccount(RemoteAccount):
 
-    def __init__(self, ssh_config, externally_routable_ip=None, logger=None):
-        super(LinuxRemoteAccount, self).__init__(ssh_config, externally_routable_ip=externally_routable_ip,
-                                                 logger=logger)
+    def __init__(self, *args, **kwargs):
+        super(LinuxRemoteAccount, self).__init__(*args, **kwargs)
         self._ssh_client = None
         self._sftp_client = None
         self.os = LINUX
+        self._log(logging.WARNING, "init linux")
 
     @property
     def local(self):

--- a/ducktape/cluster/linux_remoteaccount.py
+++ b/ducktape/cluster/linux_remoteaccount.py
@@ -24,7 +24,6 @@ class LinuxRemoteAccount(RemoteAccount):
         self._ssh_client = None
         self._sftp_client = None
         self.os = LINUX
-        self._log(logging.WARNING, "init linux")
 
     @property
     def local(self):

--- a/ducktape/cluster/linux_remoteaccount.py
+++ b/ducktape/cluster/linux_remoteaccount.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from ducktape.cluster.cluster_spec import LINUX
 from ducktape.cluster.remoteaccount import RemoteAccount
 

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -32,7 +32,8 @@ class LocalhostCluster(Cluster):
         self._available_nodes = NodeContainer()
         for i in range(num_nodes):
             ssh_config = RemoteAccountSSHConfig("localhost%d" % i, hostname="localhost", port=22)
-            self._available_nodes.add_node(ClusterNode(LinuxRemoteAccount(ssh_config, ssh_exception_checks=kwargs.get("ssh_exception_checks"))))
+            self._available_nodes.add_node(ClusterNode(LinuxRemoteAccount(ssh_config,
+                              ssh_exception_checks=kwargs.get("ssh_exception_checks"))))
         self._in_use_nodes = NodeContainer()
 
     def do_alloc(self, cluster_spec):

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -32,8 +32,9 @@ class LocalhostCluster(Cluster):
         self._available_nodes = NodeContainer()
         for i in range(num_nodes):
             ssh_config = RemoteAccountSSHConfig("localhost%d" % i, hostname="localhost", port=22)
-            self._available_nodes.add_node(ClusterNode(LinuxRemoteAccount(ssh_config,
-                              ssh_exception_checks=kwargs.get("ssh_exception_checks"))))
+            self._available_nodes.add_node(ClusterNode(
+                LinuxRemoteAccount(ssh_config,
+                                   ssh_exception_checks=kwargs.get("ssh_exception_checks"))))
         self._in_use_nodes = NodeContainer()
 
     def do_alloc(self, cluster_spec):

--- a/ducktape/cluster/localhost.py
+++ b/ducktape/cluster/localhost.py
@@ -32,7 +32,7 @@ class LocalhostCluster(Cluster):
         self._available_nodes = NodeContainer()
         for i in range(num_nodes):
             ssh_config = RemoteAccountSSHConfig("localhost%d" % i, hostname="localhost", port=22)
-            self._available_nodes.add_node(ClusterNode(LinuxRemoteAccount(ssh_config)))
+            self._available_nodes.add_node(ClusterNode(LinuxRemoteAccount(ssh_config, ssh_exception_checks=kwargs.get("ssh_exception_checks"))))
         self._in_use_nodes = NodeContainer()
 
     def do_alloc(self, cluster_spec):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -27,13 +27,13 @@ import warnings
 from ducktape.utils.http_utils import HttpMixin
 from ducktape.utils.util import wait_until
 from ducktape.errors import DucktapeError
-
+import socket
 
 def check_ssh(method):
     def wrapper(self, *args, **kwargs):
         try:
             return method(self, *args, **kwargs)
-        except (SSHException, NoValidConnectionsError) as e:
+        except (SSHException, NoValidConnectionsError, socket.error) as e:
             self._log(logging.WARNING, "checking")
             self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
             if self._custom_ssh_exception_checks:

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -40,7 +40,7 @@ def check_ssh(method):
                 self._log(logging.DEBUG, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
                 for func in self._custom_ssh_exception_checks:
                     func(e, self)
-            raise e
+            raise
     return wrapper
 
 
@@ -156,9 +156,6 @@ class RemoteAccount(HttpMixin):
         self._ssh_client = None
         self._sftp_client = None
         self._custom_ssh_exception_checks = ssh_exception_checks
-        self._log(logging.WARNING, "init done")
-        self._log(logging.WARNING, "ssh_exception_checks")
-        self._log(logging.WARNING, ssh_exception_checks)
 
     @property
     def operating_system(self):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -29,6 +29,7 @@ from ducktape.utils.util import wait_until
 from ducktape.errors import DucktapeError
 import socket
 
+
 def check_ssh(method):
     def wrapper(self, *args, **kwargs):
         try:
@@ -41,6 +42,7 @@ def check_ssh(method):
                     func(e, self)
             raise e
     return wrapper
+
 
 class RemoteAccountSSHConfig(object):
     def __init__(self, host=None, hostname=None, user=None, port=None, password=None, identityfile=None, **kwargs):
@@ -196,18 +198,6 @@ class RemoteAccount(HttpMixin):
             self._ssh_client.close()
         self._ssh_client = client
         self._set_sftp_client()
-
-    def _check_ssh(self, e):
-        self._log(logging.WARNING, "STARTING CHECKS")
-        self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
-        for func in self._custom_ssh_exception_checks:
-            func(e, self)
-
-    def register_ssh_exception_check(self, func):
-        if callable(func):
-            self._custom_ssh_exception_checks.append(func)
-        elif isinstance(func, str):
-            getattr
 
     @property
     def ssh_client(self):
@@ -528,6 +518,7 @@ class RemoteAccount(HttpMixin):
             # in this case we'll copy as:
             #   path/to/src_name -> dest/src_name
             dest = self._re_anchor_basename(src, dest)
+
         if self.isfile(src):
             self.sftp_client.get(src, dest)
         elif self.isdir(src):
@@ -555,6 +546,7 @@ class RemoteAccount(HttpMixin):
             # in this case we'll copy as:
             #   path/to/src_name -> dest/src_name
             dest = self._re_anchor_basename(src, dest)
+
         if os.path.isfile(src):
             # local to remote
             self.sftp_client.put(src, dest)
@@ -629,7 +621,7 @@ class RemoteAccount(HttpMixin):
             f.write(contents)
 
     _DEFAULT_PERMISSIONS = int('755', 8)
-    
+
     @check_ssh
     def mkdir(self, path, mode=_DEFAULT_PERMISSIONS):
         self.sftp_client.mkdir(path, mode)

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -34,16 +34,11 @@ def check_ssh(method):
         try:
             return method(self, *args, **kwargs)
         except (SSHException, NoValidConnectionsError, socket.error) as e:
-            self._log(logging.WARNING, "checking")
-            self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
             if self._custom_ssh_exception_checks:
-                self._log(logging.WARNING, "STARTING CHECKS")
-                self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
+                self._log(logging.DEBUG, "starting ssh checks:")
+                self._log(logging.DEBUG, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
                 for func in self._custom_ssh_exception_checks:
                     func(e, self)
-            raise e
-        except Exception as e:
-            self._log(logging.WARNING, "non connection error of type {}: {}".format(type(e), e))
             raise e
     return wrapper
 

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -34,6 +34,8 @@ def check_ssh(method):
         try:
             return method(self, *args, **kwargs)
         except (SSHException, NoValidConnectionsError) as e:
+            self._log(logging.WARNING, "checking")
+            self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
             if self._custom_ssh_exception_checks:
                 self._log(logging.WARNING, "STARTING CHECKS")
                 self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -42,6 +42,9 @@ def check_ssh(method):
                 for func in self._custom_ssh_exception_checks:
                     func(e, self)
             raise e
+        except Exception as e:
+            self._log(logging.WARNING, "non connection error of type {}: {}".format(type(e), e))
+            raise e
     return wrapper
 
 class RemoteAccountSSHConfig(object):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 import logging
 import os
 from paramiko import SSHClient, SSHConfig, MissingHostKeyPolicy
+from paramiko.ssh_exception import SSHException, NoValidConnectionsError
 import shutil
 import signal
 import socket
@@ -27,6 +28,19 @@ from ducktape.utils.http_utils import HttpMixin
 from ducktape.utils.util import wait_until
 from ducktape.errors import DucktapeError
 
+
+def check_ssh(method):
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except (SSHException, NoValidConnectionsError) as e:
+            if self._custom_ssh_exception_checks:
+                self._log(logging.WARNING, "STARTING CHECKS")
+                self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
+                for func in self._custom_ssh_exception_checks:
+                    func(e, self)
+            raise e
+    return wrapper
 
 class RemoteAccountSSHConfig(object):
     def __init__(self, host=None, hostname=None, user=None, port=None, password=None, identityfile=None, **kwargs):
@@ -120,7 +134,7 @@ class RemoteAccount(HttpMixin):
     Each operating system has its own RemoteAccount implementation.
     """
 
-    def __init__(self, ssh_config, externally_routable_ip=None, logger=None):
+    def __init__(self, ssh_config, externally_routable_ip=None, logger=None, ssh_exception_checks=[]):
         # Instance of RemoteAccountSSHConfig - use this instead of a dict, because we need the entire object to
         # be hashable
         self.ssh_config = ssh_config
@@ -139,6 +153,10 @@ class RemoteAccount(HttpMixin):
         self.os = None
         self._ssh_client = None
         self._sftp_client = None
+        self._custom_ssh_exception_checks = ssh_exception_checks
+        self._log(logging.WARNING, "init done")
+        self._log(logging.WARNING, "ssh_exception_checks")
+        self._log(logging.WARNING, ssh_exception_checks)
 
     @property
     def operating_system(self):
@@ -159,6 +177,7 @@ class RemoteAccount(HttpMixin):
         msg = "%s: %s" % (str(self), msg)
         self.logger.log(level, msg, *args, **kwargs)
 
+    @check_ssh
     def _set_ssh_client(self):
         client = SSHClient()
         client.set_missing_host_key_policy(IgnoreMissingHostKeyPolicy())
@@ -177,6 +196,18 @@ class RemoteAccount(HttpMixin):
             self._ssh_client.close()
         self._ssh_client = client
         self._set_sftp_client()
+
+    def _check_ssh(self, e):
+        self._log(logging.WARNING, "STARTING CHECKS")
+        self._log(logging.WARNING, "\n".join(repr(f) for f in self._custom_ssh_exception_checks))
+        for func in self._custom_ssh_exception_checks:
+            func(e, self)
+
+    def register_ssh_exception_check(self, func):
+        if callable(func):
+            self._custom_ssh_exception_checks.append(func)
+        elif isinstance(func, str):
+            getattr
 
     @property
     def ssh_client(self):
@@ -250,6 +281,7 @@ class RemoteAccount(HttpMixin):
         except Exception:
             return False
 
+    @check_ssh
     def ssh(self, cmd, allow_fail=False):
         """Run the given command on the remote host, and block until the command has finished running.
 
@@ -283,6 +315,7 @@ class RemoteAccount(HttpMixin):
 
         return exit_status
 
+    @check_ssh
     def ssh_capture(self, cmd, allow_fail=False, callback=None, combine_stderr=True, timeout_sec=None):
         """Run the given command asynchronously via ssh, and return an SSHOutputIter object.
 
@@ -336,6 +369,7 @@ class RemoteAccount(HttpMixin):
 
         return SSHOutputIter(output_generator, stdout)
 
+    @check_ssh
     def ssh_output(self, cmd, allow_fail=False, combine_stderr=True, timeout_sec=None):
         """Runs the command via SSH and captures the output, returning it as a string.
 
@@ -487,13 +521,13 @@ class RemoteAccount(HttpMixin):
 
         return os.path.join(directory, path_basename)
 
+    @check_ssh
     def copy_from(self, src, dest):
         if os.path.isdir(dest):
             # dest is an existing directory, so assuming src looks like path/to/src_name,
             # in this case we'll copy as:
             #   path/to/src_name -> dest/src_name
             dest = self._re_anchor_basename(src, dest)
-
         if self.isfile(src):
             self.sftp_client.get(src, dest)
         elif self.isdir(src):
@@ -513,6 +547,7 @@ class RemoteAccount(HttpMixin):
         warnings.warn("scp_to is now deprecated. Please use copy_to")
         self.copy_to(src, dest)
 
+    @check_ssh
     def copy_to(self, src, dest):
 
         if self.isdir(dest):
@@ -520,7 +555,6 @@ class RemoteAccount(HttpMixin):
             # in this case we'll copy as:
             #   path/to/src_name -> dest/src_name
             dest = self._re_anchor_basename(src, dest)
-
         if os.path.isfile(src):
             # local to remote
             self.sftp_client.put(src, dest)
@@ -537,6 +571,7 @@ class RemoteAccount(HttpMixin):
                     # TODO what about uncopyable file types?
                     pass
 
+    @check_ssh
     def islink(self, path):
         try:
             # stat should follow symlinks
@@ -545,6 +580,7 @@ class RemoteAccount(HttpMixin):
         except Exception:
             return False
 
+    @check_ssh
     def isdir(self, path):
         try:
             # stat should follow symlinks
@@ -553,6 +589,7 @@ class RemoteAccount(HttpMixin):
         except Exception:
             return False
 
+    @check_ssh
     def exists(self, path):
         """Test that the path exists, but don't follow symlinks."""
         try:
@@ -562,6 +599,7 @@ class RemoteAccount(HttpMixin):
         except IOError:
             return False
 
+    @check_ssh
     def isfile(self, path):
         """Imitates semantics of os.path.isfile
 
@@ -578,6 +616,7 @@ class RemoteAccount(HttpMixin):
     def open(self, path, mode='r'):
         return self.sftp_client.open(path, mode)
 
+    @check_ssh
     def create_file(self, path, contents):
         """Create file at path, with the given contents.
 
@@ -585,12 +624,14 @@ class RemoteAccount(HttpMixin):
         """
         # TODO: what should semantics be if path exists? what actually happens if it already exists?
         # TODO: what happens if the base part of the path does not exist?
+
         with self.sftp_client.open(path, "w") as f:
             f.write(contents)
 
     _DEFAULT_PERMISSIONS = int('755', 8)
+    
+    @check_ssh
     def mkdir(self, path, mode=_DEFAULT_PERMISSIONS):
-
         self.sftp_client.mkdir(path, mode)
 
     def mkdirs(self, path, mode=_DEFAULT_PERMISSIONS):

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -27,7 +27,6 @@ import warnings
 from ducktape.utils.http_utils import HttpMixin
 from ducktape.utils.util import wait_until
 from ducktape.errors import DucktapeError
-import socket
 
 
 def check_ssh(method):

--- a/ducktape/cluster/vagrant.py
+++ b/ducktape/cluster/vagrant.py
@@ -36,7 +36,7 @@ class VagrantCluster(JsonCluster):
     def __init__(self, *args, **kwargs):
         self._is_aws = None
         is_read_from_file = False
-
+        self.ssh_exception_checks = kwargs.get("ssh_exception_checks")
         cluster_file = kwargs.get("cluster_file")
         if cluster_file is not None:
             try:
@@ -51,7 +51,7 @@ class VagrantCluster(JsonCluster):
                 "nodes": self._get_nodes_from_vagrant()
             }
 
-        super(VagrantCluster, self).__init__(cluster_json)
+        super(VagrantCluster, self).__init__(cluster_json, *args, **kwargs)
 
         # If cluster file is specified but the cluster info is not read from it, write the cluster info into the file
         if not is_read_from_file and cluster_file is not None:
@@ -82,7 +82,7 @@ class VagrantCluster(JsonCluster):
 
             account = None
             try:
-                account = JsonCluster.make_remote_account(ssh_config)
+                account = JsonCluster.make_remote_account(ssh_config, ssh_exception_checks=self.ssh_exception_checks)
                 externally_routable_ip = account.fetch_externally_routable_ip(self.is_aws)
             finally:
                 if account:

--- a/ducktape/cluster/windows_remoteaccount.py
+++ b/ducktape/cluster/windows_remoteaccount.py
@@ -37,9 +37,8 @@ class WindowsRemoteAccount(RemoteAccount):
 
     WINRM_USERNAME = "Administrator"
 
-    def __init__(self, ssh_config, externally_routable_ip=None, logger=None):
-        super(WindowsRemoteAccount, self).__init__(ssh_config, externally_routable_ip=externally_routable_ip,
-                                                   logger=logger)
+    def __init__(self, *args, **kwargs):
+        super(WindowsRemoteAccount, self).__init__(*args, **kwargs)
         self.os = WINDOWS
         self._winrm_client = None
 

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -185,13 +185,8 @@ def main():
 
         cluster_kwargs = {"cluster_file": args_dict["cluster_file"]}
         checkers = [load_function(func_path) for func_path in args_dict["ssh_checker_function"]]
-        session_logger.warning("checkers")
-        session_logger.warning(args_dict["ssh_checker_function"])
-        session_logger.warning(",".join(repr(checker) for checker in checkers))
         if checkers:
             cluster_kwargs['ssh_exception_checks'] = checkers
-        session_logger.warning(cluster_kwargs)
-        session_logger.warning(cluster_class)
         cluster = cluster_class(**cluster_kwargs)
         for ctx in tests:
             # Note that we're attaching a reference to cluster

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -185,8 +185,13 @@ def main():
 
         cluster_kwargs = {"cluster_file": args_dict["cluster_file"]}
         checkers = [load_function(func_path) for func_path in args_dict["ssh_checker_function"]]
+        session_logger.warning("checkers")
+        session_logger.warning(args_dict["ssh_checker_function"])
+        session_logger.warning(",".join(repr(checker) for checker in checkers))
         if checkers:
             cluster_kwargs['ssh_exception_checks'] = checkers
+        session_logger.warning(cluster_kwargs)
+        session_logger.warning(cluster_class)
         cluster = cluster_class(**cluster_kwargs)
         for ctx in tests:
             # Note that we're attaching a reference to cluster

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -34,6 +34,7 @@ from ducktape.tests.runner import TestRunner
 from ducktape.tests.session import SessionContext, SessionLoggerMaker
 from ducktape.tests.session import generate_session_id, generate_results_dir
 from ducktape.utils.local_filesystem_utils import mkdir_p
+from ducktape.utils.util import load_function
 
 
 def extend_import_paths(paths):
@@ -181,7 +182,12 @@ def main():
         (cluster_mod_name, cluster_class_name) = args_dict["cluster"].rsplit('.', 1)
         cluster_mod = importlib.import_module(cluster_mod_name)
         cluster_class = getattr(cluster_mod, cluster_class_name)
-        cluster = cluster_class(cluster_file=args_dict["cluster_file"])
+
+        cluster_kwargs = {"cluster_file": args_dict["cluster_file"]}
+        checkers = [load_function(func_path) for func_path in args_dict["ssh_checker_function"]]
+        if checkers:
+            cluster_kwargs['ssh_exception_checks'] = checkers
+        cluster = cluster_class(**cluster_kwargs)
         for ctx in tests:
             # Note that we're attaching a reference to cluster
             # only after test context objects have been instantiated

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -77,6 +77,10 @@ def create_ducktape_parser():
     parser.add_argument("--test-runner-timeout", action="store", type=int, default=1800000,
                         help="Amount of time in milliseconds between test communicating between the test runner"
                              " before a timeout error occurs. Default is 30 minutes")
+    parser.add_argument("--ssh-checker-function", action="store", type=str, nargs="+",
+                        help="Python module path to a function that takes an exception and a remote account that will "
+                        "be called when an ssh error occurs, this can give some validation or better logging when an ssh "
+                        "error occurs")
     return parser
 
 

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -78,9 +78,9 @@ def create_ducktape_parser():
                         help="Amount of time in milliseconds between test communicating between the test runner"
                              " before a timeout error occurs. Default is 30 minutes")
     parser.add_argument("--ssh-checker-function", action="store", type=str, nargs="+",
-                        help="Python module path to a function that takes an exception and a remote account that will "
+                        help="Python module path(s) to a function that takes an exception and a remote account that will "
                         "be called when an ssh error occurs, this can give some validation or better logging when an ssh "
-                        "error occurs")
+                        "error occurs. Specify any number of module paths after this flag to be called.")
     return parser
 
 

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -78,9 +78,10 @@ def create_ducktape_parser():
                         help="Amount of time in milliseconds between test communicating between the test runner"
                              " before a timeout error occurs. Default is 30 minutes")
     parser.add_argument("--ssh-checker-function", action="store", type=str, nargs="+",
-                        help="Python module path(s) to a function that takes an exception and a remote account that will "
-                        "be called when an ssh error occurs, this can give some validation or better logging when an ssh "
-                        "error occurs. Specify any number of module paths after this flag to be called.")
+                        help="Python module path(s) to a function that takes an exception and a remote account"
+                        " that will be called when an ssh error occurs, this can give some "
+                        "validation or better logging when an ssh error occurs. Specify any "
+                        "number of module paths after this flag to be called.")
     return parser
 
 

--- a/ducktape/utils/util.py
+++ b/ducktape/utils/util.py
@@ -53,3 +53,7 @@ def package_is_installed(package_name):
 def ducktape_version():
     """Return string representation of current ducktape version."""
     return __ducktape_version__
+
+def load_function(func_module_path):
+    module, function = func_module_path.rsplit(".", 1)
+    return getattr(importlib.import_module(module), function)

--- a/ducktape/utils/util.py
+++ b/ducktape/utils/util.py
@@ -54,6 +54,7 @@ def ducktape_version():
     """Return string representation of current ducktape version."""
     return __ducktape_version__
 
+
 def load_function(func_module_path):
     """Loads and returns a function from a module path seperated by '.'s"""
     module, function = func_module_path.rsplit(".", 1)

--- a/ducktape/utils/util.py
+++ b/ducktape/utils/util.py
@@ -55,5 +55,10 @@ def ducktape_version():
     return __ducktape_version__
 
 def load_function(func_module_path):
+    """Loads and returns a function from a module path seperated by '.'s"""
     module, function = func_module_path.rsplit(".", 1)
-    return getattr(importlib.import_module(module), function)
+    try:
+        return getattr(importlib.import_module(module), function)
+    except AttributeError:
+        raise Exception("Function could not be loaded from the module path {}, "
+                        "verify that it is '.' seperated".format(func_module_path))

--- a/tests/cluster/check_remoteaccount.py
+++ b/tests/cluster/check_remoteaccount.py
@@ -30,11 +30,15 @@ import time
 class DummyException(Exception):
     pass
 
+
 def raise_error_checker(error, remote_account):
-    raise DummyException("dummy raise: {}\nfrom: {}".format(error, remote_account))    
+    raise DummyException("dummy raise: {}\nfrom: {}".format(error, remote_account))
+
 
 def raise_no_error_checker(error, remote_account):
     pass
+
+
 class SimpleServer(object):
     """Helper class which starts a simple server listening on localhost at the specified port
     """
@@ -96,12 +100,12 @@ class CheckRemoteAccount(object):
             assert abs(actual_timeout - timeout) / timeout < 1
 
     @pytest.mark.parametrize("checkers", [[raise_error_checker],
-                            [raise_no_error_checker, raise_error_checker],
-                            [raise_error_checker, raise_no_error_checker]])
+                                          [raise_no_error_checker, raise_error_checker],
+                                          [raise_error_checker, raise_no_error_checker]])
     def check_ssh_checker(self, checkers):
         self.server.start()
         self.account = RemoteAccount(RemoteAccountSSHConfig.from_string(
-        """
+            """
         Host dummy_host.com
             Hostname dummy_host.name.com
             Port 22

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -89,11 +89,12 @@ class MockNode(object):
 class MockAccount(LinuxRemoteAccount):
     """Mock node.account object. It's Linux because tests are run in Linux."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         ssh_config = RemoteAccountSSHConfig(
             host="localhost",
             user=None,
             hostname="localhost",
-            port=22)
+            port=22,
+            **kwargs)
 
         super(MockAccount, self).__init__(ssh_config, externally_routable_ip="localhost", logger=None)

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -94,7 +94,6 @@ class MockAccount(LinuxRemoteAccount):
             host="localhost",
             user=None,
             hostname="localhost",
-            port=22,
-            **kwargs)
+            port=22)
 
-        super(MockAccount, self).__init__(ssh_config, externally_routable_ip="localhost", logger=None)
+        super(MockAccount, self).__init__(ssh_config, externally_routable_ip="localhost", logger=None, **kwargs)


### PR DESCRIPTION
One common point of failure for ducktape is paramiko, when a remote account fails, we generally get a non useful error message that has no attachment to the node that is being ran.  This PR addresses this issue by adding a flag to ducktape that allows you to specify a specific function that takes in an error and a remote account, that will then be ran on an ssh failure.  For instance, if you are running aws instances, you can write your own aws command that validates that the node is still running on aws, and then run this on an ssh failure. 