### PR TITLE
reporter: print report and failures at the end

### DIFF
--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -99,9 +99,9 @@ class SummaryReporter(object):
 
 
 class SimpleSummaryReporter(SummaryReporter):
-    def header_string(self):
-        """Header lines of the report"""
-        header_lines = [
+    def footer_string(self):
+        """Footer lines of the report"""
+        footer_lines = [
             "=" * self.width,
             "SESSION REPORT (ALL TESTS)",
             "ducktape version: %s" % ducktape_version(),
@@ -114,15 +114,28 @@ class SimpleSummaryReporter(SummaryReporter):
             "=" * self.width
         ]
 
-        return "\n".join(header_lines)
+        return "\n".join(footer_lines)
 
     def report_string(self):
         """Get the whole report string."""
-        report_lines = [
-            self.header_string()]
 
-        report_lines.extend(
-            [SingleResultReporter(result).result_string() + "\n" + "-" * self.width for result in self.results])
+        passed = []
+        ignored = []
+        failed = []
+        for result in self.results:
+            if result.test_status == FAIL:
+                failed.append(result)
+            elif result.test_status == IGNORE:
+                ignored.append(result)
+            else:
+                passed.append(result)
+
+        ordered_results = passed + ignored + failed
+
+        report_lines = \
+            [SingleResultReporter(result).result_string() + "\n" + "-" * self.width for result in ordered_results]
+
+        report_lines.append(self.footer_string())
 
         return "\n".join(report_lines)
 


### PR DESCRIPTION
Change the order of output for test reporting. The new order is structured to make it easier to consume from the tail end of the output, common in settings like CI.

The new order is [passed, ignored, failed, summary report]. Here is an example:

```
--------------------------------------------------------------------------------
test_id:    rptest.tests.describe_topics_test.DescribeTopicsTest.test_describe_topics
status:     PASS
run time:   18.640 seconds
--------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_create_topic
status:     PASS
run time:   10.310 seconds
--------------------------------------------------------------------------------
test_id:    rptest.tests.describe_topics_test.DescribeTopicsTest.test_xxx
status:     IGNORE
run time:   0.000 seconds
--------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_consume_newest
status:     IGNORE
run time:   0.000 seconds
--------------------------------------------------------------------------------
test_id:    rptest.tests.bytes_sent_test.BytesSentTest.test_bytes_sent
status:     FAIL
run time:   8.883 seconds


    NameError("name 'blah' is not defined")
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 135, in run
    data = self.run_test()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 215, in run_test
    return self.test_context.function(self.test)
  File "/root/tests/rptest/services/cluster.py", line 35, in wrapped
    r = f(self, *args, **kwargs)
  File "/root/tests/rptest/tests/bytes_sent_test.py", line 85, in test_bytes_sent
    blah
NameError: name 'blah' is not defined

--------------------------------------------------------------------------------
test_id:    rptest.tests.rpk_topic_test.RpkToolTest.test_consume_oldest
status:     FAIL
run time:   6.623 seconds


    NameError("name 'asdf' is not defined")
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 135, in run
    data = self.run_test()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 215, in run_test
    return self.test_context.function(self.test)
  File "/root/tests/rptest/services/cluster.py", line 35, in wrapped
    r = f(self, *args, **kwargs)
  File "/root/tests/rptest/tests/rpk_topic_test.py", line 131, in test_consume_oldest
    asdf
NameError: name 'asdf' is not defined

--------------------------------------------------------------------------------
================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.8
session_id:       2022-01-19--004
run time:         3 minutes 27.125 seconds
tests run:        11
passed:           7
failed:           2
ignored:          2
================================================================================
```