### PR TITLE
locked two more requirements to versions that support python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,11 @@ setup(name="ducktape",
                         'pycryptodome==3.8.2',
                         'more-itertools==5.0.0',
                         'tox==3.13.2',
-                        'six==1.12.0'],
+                        'six==1.12.0',
+                        # for the following packages these are the last versions supporting python 2
+                        'pynacl==1.4.0',
+                        'filelock==3.2.1'
+                        ],
       tests_require=['pytest==4.6.5',
                      'mock==3.0.5',
                      'psutil==5.6.3',


### PR DESCRIPTION
Source: 
https://py-filelock.readthedocs.io/en/latest/changelog.html#v3-3-0-2021-10-03
https://pynacl.readthedocs.io/en/latest/changelog

While I haven't personally seen ducktape breaking because of this (yet), attempting to install these dependencies in the internal system test framework that's using ducktape caused some troubles.
These packages are transitive dependencies and their versions are not specified strictly, but rather as a range, by the packages that require them. This could lead to some combinations of requirements working and some don't. 
We hardcode them to the versions that most definitely work.

Tested by running tox.