### PR TITLE
Removed tox and locked cryptography version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,11 @@ setup(name="ducktape",
                         'pyzmq==18.1.0',
                         'pycryptodome==3.8.2',
                         'more-itertools==5.0.0',
-                        'tox==3.13.2',
                         'six==1.12.0',
                         # for the following packages these are the last versions supporting python 2
                         'pynacl==1.4.0',
-                        'filelock==3.2.1'
+                        'filelock==3.2.1',
+                        'cryptography==3.3.2'
                         ],
       tests_require=['pytest==4.6.5',
                      'mock==3.0.5',


### PR DESCRIPTION
This is again to maintain python 2 compatibility. 

Cryptography is a transitive dep, specified by several of packages, none of which has an upper bound, so we lock it to the last py2-compatible version.
See https://cryptography.io/en/latest/changelog/#v3-4

Removing tox because it pulls virtualenv and that one pulls a bunch of stuff. But more importantly it is a test dependency, not a prod one, so I don't think it belongs to direct ducktape dependencies. And we don't run it in an automated fashion anywhere anyway.