### PR TITLE
Add deflake feature to Ducktape

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     name = "ducktape" + i.to_s
     config.vm.define name do |worker|
       worker.vm.hostname = name
-      worker.vm.network :private_network, ip: "192.168.50." + (150 + i).to_s
+      worker.vm.network :private_network, ip: "192.168.56." + (150 + i).to_s
     end
   }
 

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -200,7 +200,8 @@ def main():
         sys.exit(1)
 
     # Run the tests
-    runner = TestRunner(cluster, session_context, session_logger, tests)
+    deflake_num = max(1, args_dict['deflake'])
+    runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
     # Report results

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -200,9 +200,10 @@ def main():
         sys.exit(1)
 
     # Run the tests
+    deflake_num = args_dict['deflake']
     if deflake_num < 1:
         session_logger.warning("specified number of deflake runs specified to be less than 1, running without deflake.")
-    deflake_num = max(1, args_dict['deflake'])
+    deflake_num = max(1, deflake_num)
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -200,6 +200,8 @@ def main():
         sys.exit(1)
 
     # Run the tests
+    if deflake_num < 1:
+        session_logger.warning("specified number of deflake runs specified to be less than 1, running without deflake.")
     deflake_num = max(1, args_dict['deflake'])
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -81,7 +81,12 @@ def create_ducktape_parser():
                         help="Python module path(s) to a function that takes an exception and a remote account"
                         " that will be called when an ssh error occurs, this can give some "
                         "validation or better logging when an ssh error occurs. Specify any "
-                        "number of module paths after this flag to be called.")
+                        "number of module paths after this flag to be called."),
+    parser.add_argument("--deflake", action="store", type=int, default=1,
+                        help=
+                        "the number of times a failed test should be ran total (including its initial run) to determin flakyness,"
+                        "when not present, deflake will not be used, and a test will be marked as either passed or failed, when enabled"
+                        "tests will be marked as flaky if it passes any of the reruns")
     return parser
 
 

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -307,6 +307,11 @@ class Service(TemplateRenderer):
             node.account.logger = None
             self.cluster.free(node)
 
+        try:
+            self.registry.remove(self)
+        except AttributeError:
+            pass
+
         self.nodes = []
 
     def run(self):

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -102,7 +102,6 @@ class Service(TemplateRenderer):
         self._stop_time = -1
         self._stop_duration_seconds = -1
         self._clean_time = -1
-        self._registries = []
 
         self._initialized = False
         self.service_id_factory = ServiceIdFactory(self)
@@ -342,9 +341,6 @@ class Service(TemplateRenderer):
             node.account.logger = None
             self.cluster.free(node)
 
-        for registry in self._registries:
-            registry.remove(self)
-
     def run(self):
         """Helper that executes run(), wait(), and stop() in sequence."""
         self.start()
@@ -383,9 +379,6 @@ class Service(TemplateRenderer):
             svc.wait()
         for svc in args:
             svc.stop()
-
-    def add_registry(self, registry):
-        self._registries.append(registry)
 
     def to_json(self):
         return {

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -64,6 +64,7 @@ class Service(TemplateRenderer):
         """
         super(Service, self).__init__(*args, **kwargs)
         # Keep track of significant events in the lifetime of this service
+        self._is_destroyed = False
         self._init_time = time.time()
         self._start_time = -1
         self._start_duration_seconds = -1
@@ -144,7 +145,8 @@ class Service(TemplateRenderer):
 
         """
         if hasattr(self.context, "services"):
-            same_services = [id(s) for s in self.context.services if type(s) == type(self)]
+            same_services = [id(s) for s in self.context.services.destroyed_services() if type(s) == type(self)]
+            same_services.extend(id(s) for s in self.context.services if type(s) == type(self))
 
             if self not in self.context.services and not self._initialized:
                 # It's possible that _order will be invoked in the constructor *before* self has been registered with
@@ -311,6 +313,7 @@ class Service(TemplateRenderer):
 
         for registry in self._registries:
             registry.remove(self)
+        self._is_destroyed = True
 
     def run(self):
         """Helper that executes run(), wait(), and stop() in sequence."""

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -23,35 +23,29 @@ import tempfile
 import time
 
 
-class AbstractServiceIdFactory:
-    def generate_service_id(self):
-        raise NotImplementedError()
-
-
-class ServiceIdFactory(AbstractServiceIdFactory):
-    def __init__(self, service):
-        self.service = service
-
-    def generate_service_id(self):
+class ServiceIdFactory:
+    def generate_service_id(self, service):
         return "{service_name}-{service_number}-{service_id}".format(
-            service_name=self.service.__class__.__name__,
-            service_number=self.service._order,
-            service_id=id(self.service)
+            service_name=service.__class__.__name__,
+            service_number=service._order,
+            service_id=id(service)
         )
 
 
-class MultiRunServiceIdFactory(AbstractServiceIdFactory):
-    def __init__(self, service, run_number):
-        self.service = service
+class MultiRunServiceIdFactory:
+    def __init__(self, run_number=1):
         self.run_number = run_number
 
-    def generate_service_id(self):
+    def generate_service_id(self, service):
         return "{run_number}-{service_name}-{service_number}-{service_id}".format(
             run_number=self.run_number,
-            service_name=self.service.__class__.__name__,
-            service_number=self.service._order,
-            service_id=id(self.service)
+            service_name=service.__class__.__name__,
+            service_number=service._order,
+            service_id=id(service)
         )
+
+
+service_id_factory = ServiceIdFactory()
 
 
 class Service(TemplateRenderer):
@@ -103,7 +97,7 @@ class Service(TemplateRenderer):
         self._clean_time = -1
 
         self._initialized = False
-        self.service_id_factory = ServiceIdFactory(self)
+        self.service_id_factory = service_id_factory
         self.cluster_spec = Service.setup_cluster_spec(num_nodes=num_nodes, cluster_spec=cluster_spec)
         self.context = context
 
@@ -155,7 +149,7 @@ class Service(TemplateRenderer):
     @property
     def service_id(self):
         """Human-readable identifier (almost certainly) unique within a test run."""
-        return self.service_id_factory.generate_service_id()
+        return self.service_id_factory.generate_service_id(self)
 
     @property
     def _order(self):

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -70,6 +70,7 @@ class Service(TemplateRenderer):
         self._stop_time = -1
         self._stop_duration_seconds = -1
         self._clean_time = -1
+        self._registries = []
 
         self._initialized = False
         self.cluster_spec = Service.setup_cluster_spec(num_nodes=num_nodes, cluster_spec=cluster_spec)
@@ -307,10 +308,8 @@ class Service(TemplateRenderer):
             node.account.logger = None
             self.cluster.free(node)
 
-        try:
-            self.registry.remove(self)
-        except AttributeError:
-            pass
+        for registry in self._registries:
+            registry.remove(self)
 
         self.nodes = []
 
@@ -352,6 +351,9 @@ class Service(TemplateRenderer):
             svc.wait()
         for svc in args:
             svc.stop()
+
+    def add_registry(self, registry):
+        self._registries.append(registry)
 
     def to_json(self):
         return {

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -54,7 +54,6 @@ class MultiRunServiceIdFactory(AbstractServiceIdFactory):
         )
 
 
-
 class Service(TemplateRenderer):
     """Service classes know how to deploy a service onto a set of nodes and then clean up after themselves.
 

--- a/ducktape/services/service.py
+++ b/ducktape/services/service.py
@@ -303,15 +303,14 @@ class Service(TemplateRenderer):
 
     def free(self):
         """Free each node. This 'deallocates' the nodes so the cluster can assign them to other services."""
-        for node in self.nodes:
+        while self.nodes:
+            node = self.nodes.pop()
             self.logger.info("%s: freeing node" % self.who_am_i(node))
             node.account.logger = None
             self.cluster.free(node)
 
         for registry in self._registries:
             registry.remove(self)
-
-        self.nodes = []
 
     def run(self):
         """Helper that executes run(), wait(), and stop() in sequence."""

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -77,8 +77,6 @@ class ServiceRegistry(object):
         for service in self._services.values():
             try:
                 service.free()
-                self._services.clear()
-                self._nodes.clear()
             except BaseException as e:
                 if isinstance(e, KeyboardInterrupt):
                     keyboard_interrupt = e
@@ -86,6 +84,8 @@ class ServiceRegistry(object):
 
         if keyboard_interrupt is not None:
             raise keyboard_interrupt
+        self._services.clear()
+        self._nodes.clear()
 
     def min_cluster_spec(self):
         """

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -34,6 +34,9 @@ class ServiceRegistry(object):
     def __repr__(self):
         return str(self._services.values())
 
+    def destroyed_services(self):
+        return iter(self._destroyed_services.values())
+
     def append(self, service):
         self._services[id(service)] = service
         self._nodes[id(service)] = [str(n.account) for n in service.nodes]

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -36,7 +36,7 @@ class ServiceRegistry(object):
     def append(self, service):
         self._services[id(service)] = service
         self._nodes[id(service)] = [str(n.account) for n in service.nodes]
-        service.registry = self
+        service.add_registry(self)
 
     def remove(self, service):
         # we don't delete the _services, as in free the node count should go to 0, so we keep it here

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -39,7 +39,8 @@ class ServiceRegistry(object):
         service.registry = self
 
     def remove(self, service):
-        # del self._services[id(service)]
+        # we don't delete the _services, as in free the node count should go to 0, so we keep it here
+        # with zero nodes to preserve history
         del self._nodes[id(service)]
 
     def to_json(self):

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -36,6 +36,11 @@ class ServiceRegistry(object):
     def append(self, service):
         self._services[id(service)] = service
         self._nodes[id(service)] = [str(n.account) for n in service.nodes]
+        service.registry = self
+
+    def remove(self, service):
+        # del self._services[id(service)]
+        del self._nodes[id(service)]
 
     def to_json(self):
         return [self._services[k].to_json() for k in self._services]
@@ -92,7 +97,9 @@ class ServiceRegistry(object):
         """
         cluster_spec = ClusterSpec()
         for service in self._services.values():
-            cluster_spec.add(service.cluster_spec)
+            # keep data of old services ran with this service registry, however don't count 0 node services in cluster spec
+            if service.nodes:
+                cluster_spec.add(service.cluster_spec)
         return cluster_spec
 
     def errors(self):

--- a/ducktape/templates/report/report.css
+++ b/ducktape/templates/report/report.css
@@ -59,6 +59,10 @@ h1, h2, h3, h4, h5, h6 {
     background-color: #6c6;
 }
 
+.flaky {
+    background-color: #dd2;
+}
+
 .fail {
     background-color: #c60; 
 }

--- a/ducktape/templates/report/report.css
+++ b/ducktape/templates/report/report.css
@@ -33,6 +33,13 @@ h1, h2, h3, h4, h5, h6 {
     padding: 2px;
 }
 
+.pre_stack_trace {
+    white-space: pre-wrap;       /* Since CSS 2.1 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}
+
 .header_row {
     font-weight: bold;
     color: white;

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -38,6 +38,7 @@
             <tr>
               <td colSpan='5' align='center'>{this.props.summary_prop.tests}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.passes}</td>
+              <td colSpan='5' align='center'>{this.props.summary_prop.flaky}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.failures}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.ignored}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.run_time}</td>
@@ -54,6 +55,7 @@
                 <tr id="summary_header_row">
                   <th colSpan='5' align='center'>Tests</th>
                   <th colSpan='5' align='center'>Passes</th>
+                  <th colSpan='5' align='center'>Flaky</th>
                   <th colSpan='5' align='center'>Failures</th>
                   <th colSpan='5' align='center'>Ignored</th>
                   <th colSpan='5' align='center'>Time</th>

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -90,7 +90,7 @@
               <td colSpan='5' align='center'><pre>{this.props.test.description}</pre></td>
               <td colSpan='5' align='center'><pre>{this.props.test.run_time}</pre></td>
               <td colSpan='5' align='center'><pre>{this.props.test.data}</pre></td>
-              <td colSpan='5' align='center'><pre>{this.props.test.summary}</pre></td>
+              <td colSpan='5' align='center'><pre className="pre_stack_trace">{this.props.test.summary}</pre></td>
               {detailCol}
             </tr>
           );

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -177,6 +177,7 @@
       SUMMARY=[{
         "tests": %(num_tests)d,
         "passes": %(num_passes)d,
+        "flaky": %(num_flaky)d,
         "failures": %(num_failures)d,
         "ignored": %(num_ignored)d,
         "run_time": '%(run_time)s'
@@ -190,6 +191,7 @@
       COLOR_KEYS=[%(test_status_names)s];
 
       PASSED_TESTS=[%(passed_tests)s];
+      FLAKY_TESTS=[%(flaky_tests)s];
       FAILED_TESTS=[%(failed_tests)s];
       IGNORED_TESTS=[%(ignored_tests)s];
 
@@ -199,6 +201,7 @@
       React.render(<TestPanel title="Failed Tests" tests={FAILED_TESTS}/>, document.getElementById('failed_test_panel'));
       React.render(<TestPanel title="Ignored Tests" tests={IGNORED_TESTS}/>, document.getElementById('ignored_test_panel'));
       React.render(<TestPanel title="Passed Tests" tests={PASSED_TESTS}/>, document.getElementById('passed_test_panel'));
+      React.render(<TestPanel title="Flaky Tests" tests={FLAKY_TESTS}/>, document.getElementById('passed_test_panel'));
     </script>
   </body>
 </html>

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -11,6 +11,7 @@
     <div id="color_key_panel"></div>
     <div id="failed_test_panel"></div>
     <div id="ignored_test_panel"></div>
+    <div id="flaky_test_panel"></div>
     <div id="passed_test_panel"></div>
     <script type="text/jsx">
       /* This small block makes it possible to use React dev tools in the Chrome browser */
@@ -202,8 +203,8 @@
       React.render(<SummaryPanel summary_props={SUMMARY}/>, document.getElementById('summary_panel'));
       React.render(<TestPanel title="Failed Tests" tests={FAILED_TESTS}/>, document.getElementById('failed_test_panel'));
       React.render(<TestPanel title="Ignored Tests" tests={IGNORED_TESTS}/>, document.getElementById('ignored_test_panel'));
+      React.render(<TestPanel title="Flaky Tests" tests={FLAKY_TESTS}/>, document.getElementById('flaky_test_panel'));
       React.render(<TestPanel title="Passed Tests" tests={PASSED_TESTS}/>, document.getElementById('passed_test_panel'));
-      React.render(<TestPanel title="Flaky Tests" tests={FLAKY_TESTS}/>, document.getElementById('passed_test_panel'));
     </script>
   </body>
 </html>

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -23,7 +23,7 @@ import pkg_resources
 
 from ducktape.utils.terminal_size import get_terminal_size
 from ducktape.utils.util import ducktape_version
-from ducktape.tests.status import PASS, FAIL, IGNORE
+from ducktape.tests.status import PASS, FAIL, IGNORE, FLAKY
 from ducktape.json_serializable import DucktapeJSONEncoder
 
 
@@ -109,6 +109,7 @@ class SimpleSummaryReporter(SummaryReporter):
             "run time:         %s" % format_time(self.results.run_time_seconds),
             "tests run:        %d" % len(self.results),
             "passed:           %d" % self.results.num_passed,
+            "flaky:            %d" % self.results.num_flaky,
             "failed:           %d" % self.results.num_failed,
             "ignored:          %d" % self.results.num_ignored,
             "=" * self.width
@@ -177,7 +178,7 @@ class JUnitReporter(object):
             elif result.test_status == IGNORE:
                 testsuite['skipped'] += 1
 
-        total = self.results.num_failed + self.results.num_ignored + self.results.num_passed
+        total = self.results.num_failed + self.results.num_ignored + self.results.num_passed + self.results.num_flaky
         # Now start building XML document
         root = ET.Element('testsuites', attrib=dict(
             name="ducktape", time=str(self.results.run_time_seconds),
@@ -261,35 +262,43 @@ class HTMLSummaryReporter(SummaryReporter):
 
         num_tests = len(self.results)
         num_passes = 0
-        failed_result_string = ""
-        passed_result_string = ""
-        ignored_result_string = ""
+        failed_result_string = []
+        passed_result_string = []
+        ignored_result_string = []
+        flaky_result_string = []
 
         for result in self.results:
             json_string = json.dumps(self.format_result(result))
             if result.test_status == PASS:
                 num_passes += 1
-                passed_result_string += json_string
-                passed_result_string += ","
+                passed_result_string.append(json_string)
+                passed_result_string.append(",")
             elif result.test_status == FAIL:
-                failed_result_string += json_string
-                failed_result_string += ","
+                failed_result_string.append(json_string)
+                failed_result_string.append(",")
+            elif result.test_status == IGNORE:
+                ignored_result_string.append(json_string)
+                ignored_result_string.append(",")
+            elif result.test_status == FLAKY:
+                flaky_result_string.append(json_string)
+                flaky_result_string.append(",")
             else:
-                ignored_result_string += json_string
-                ignored_result_string += ","
+                raise Exception("Unknown test status in report: {}".format(result.test_status.to_json()))
 
         args = {
             'ducktape_version': ducktape_version(),
             'num_tests': num_tests,
             'num_passes': self.results.num_passed,
+            'num_flaky': self.results.num_flaky,
             'num_failures': self.results.num_failed,
             'num_ignored': self.results.num_ignored,
             'run_time': format_time(self.results.run_time_seconds),
             'session': self.results.session_context.session_id,
-            'passed_tests': passed_result_string,
-            'failed_tests': failed_result_string,
-            'ignored_tests': ignored_result_string,
-            'test_status_names': ",".join(["\'%s\'" % str(status) for status in [PASS, FAIL, IGNORE]])
+            'passed_tests': "".join(passed_result_string),
+            'flaky_test': "".join(flaky_result_string),
+            'failed_tests': "".join(failed_result_string),
+            'ignored_tests': "".join(ignored_result_string),
+            'test_status_names': ",".join(["\'%s\'" % str(status) for status in [PASS, FAIL, IGNORE, FLAKY]])
         }
 
         html = template % args

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -295,7 +295,7 @@ class HTMLSummaryReporter(SummaryReporter):
             'run_time': format_time(self.results.run_time_seconds),
             'session': self.results.session_context.session_id,
             'passed_tests': "".join(passed_result_string),
-            'flaky_test': "".join(flaky_result_string),
+            'flaky_tests': "".join(flaky_result_string),
             'failed_tests': "".join(failed_result_string),
             'ignored_tests': "".join(ignored_result_string),
             'test_status_names': ",".join(["\'%s\'" % str(status) for status in [PASS, FAIL, IGNORE, FLAKY]])

--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -21,7 +21,7 @@ from ducktape.json_serializable import DucktapeJSONEncoder
 from ducktape.tests.reporter import SingleResultFileReporter
 from ducktape.utils.local_filesystem_utils import mkdir_p
 from ducktape.utils.util import ducktape_version
-from ducktape.tests.status import PASS, FAIL, IGNORE
+from ducktape.tests.status import FLAKY, PASS, FAIL, IGNORE
 
 
 class TestResult(object):
@@ -162,6 +162,10 @@ class TestResults(object):
         return len([r for r in self._results if r.test_status == IGNORE])
 
     @property
+    def num_flaky(self):
+        return len([r for r in self._results if r.test_status == FLAKY])
+
+    @property
     def run_time_seconds(self):
         if self.start_time < 0:
             return -1
@@ -203,8 +207,7 @@ class TestResults(object):
             cluster_utilization = (1.0 / len(self.cluster)) * (1.0 / self.run_time_seconds) * \
                 sum([r.nodes_used * r.run_time_seconds for r in self])
             parallelism = sum([r.run_time_seconds for r in self._results]) / self.run_time_seconds
-
-        return {
+        result = {
             "ducktape_version": ducktape_version(),
             "session_context": self.session_context,
             "run_time_seconds": self.run_time_seconds,
@@ -221,3 +224,6 @@ class TestResults(object):
             "parallelism": parallelism,
             "results": [r for r in self._results]
         }
+        if self.num_flaky:
+            result['num_flaky'] = self.num_flaky
+        return result

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -84,7 +84,7 @@ class TestRunner(object):
     # When set to True, the test runner will finish running/cleaning the current test, but it will not run any more
     stop_testing = False
 
-    def __init__(self, cluster, session_context, session_logger, tests, deflake_num
+    def __init__(self, cluster, session_context, session_logger, tests, deflake_num,
                  min_port=ConsoleDefaults.TEST_DRIVER_MIN_PORT,
                  max_port=ConsoleDefaults.TEST_DRIVER_MAX_PORT):
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -84,7 +84,7 @@ class TestRunner(object):
     # When set to True, the test runner will finish running/cleaning the current test, but it will not run any more
     stop_testing = False
 
-    def __init__(self, cluster, session_context, session_logger, tests,
+    def __init__(self, cluster, session_context, session_logger, tests, deflake_num
                  min_port=ConsoleDefaults.TEST_DRIVER_MIN_PORT,
                  max_port=ConsoleDefaults.TEST_DRIVER_MAX_PORT):
 
@@ -100,6 +100,8 @@ class TestRunner(object):
         self.event_response = EventResponseFactory()
         self.hostname = "localhost"
         self.receiver = Receiver(min_port, max_port)
+
+        self.deflake_num = deflake_num
 
         self.session_context = session_context
         self.max_parallel = session_context.max_parallel
@@ -241,7 +243,8 @@ class TestRunner(object):
                 TestContext.logger_name(test_context, current_test_counter),
                 TestContext.results_dir(test_context, current_test_counter),
                 self.session_context.debug,
-                self.session_context.fail_bad_cluster_utilization
+                self.session_context.fail_bad_cluster_utilization,
+                self.deflake_num
             ])
 
         self._client_procs[test_key] = proc

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -183,7 +183,7 @@ class RunnerClient(object):
         if num_runs > 1:
             # for reporting purposes report all services
             self.test_context.services = all_services
-        # for flaky tests, we report the start and end time of the successfull run, and not the whole run period
+        # for flaky tests, we report the start and end time of the successful run, and not the whole run period
         result = TestResult(
             self.test_context,
             self.test_index,
@@ -329,7 +329,7 @@ class Sender(object):
 
                 if sockets.get(self.socket) == zmq.POLLIN:
                     reply = self.socket.recv()
-                    if reply: 
+                    if reply:
                         return self.serde.deserialize(reply)
                     else:
                         # send another request...

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -109,10 +109,9 @@ class RunnerClient(object):
         summary = []
         data = None
 
-        num_runs = self.deflake_num
-        while test_status == FAIL and num_runs > 0:
-            num_runs -= 1
-            self.log(logging.WARNING, "on run {}/{}".format(self.deflake_num - num_runs, self.deflake_num))
+        num_runs = 1
+        while test_status == FAIL and num_runs <= self.deflake_num:
+            self.log(logging.WARNING, "on run {}/{}".format(num_runs, self.deflake_num))
             try:
                 # Results from this test, as well as logs will be dumped here
                 mkdir_p(TestContext.results_dir(self.test_context, self.test_index))
@@ -142,7 +141,7 @@ class RunnerClient(object):
 
                 data = self.run_test()
 
-                test_status = PASS if num_runs == self.deflake_num - 1 else FLAKY
+                test_status = PASS if num_runs == 1 else FLAKY
                 self.log(logging.INFO, "{} TEST".format(test_status.to_json()))
 
             except BaseException as e:
@@ -161,6 +160,7 @@ class RunnerClient(object):
                     service_errors = self.test_context.services.errors()
                     if service_errors:
                         summary.extend(["\n\n", service_errors])
+                num_runs += 1
 
         summary = "".join(summary)
         test_status, summary = self._check_cluster_utilization(test_status, summary)

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -149,6 +149,8 @@ class RunnerClient(object):
                 test_status = FAIL
                 err_trace = self._exc_msg(e)
                 summary.append(err_trace)
+                if num_runs != self.deflake_num:
+                    summary.append("~" * max(len(l) for l in err_trace.split('\n')) + "\n")
                 self.log(logging.INFO, "FAIL: " + err_trace)
 
             finally:

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -24,6 +24,7 @@ from six import iteritems
 from ducktape.tests.event import ClientEventFactory
 from ducktape.tests.loader import TestLoader
 from ducktape.tests.serde import SerDe
+from ducktape.tests.status import FLAKY
 from ducktape.tests.test import test_logger, TestContext
 
 from ducktape.tests.result import TestResult, IGNORE, PASS, FAIL
@@ -39,7 +40,7 @@ class RunnerClient(object):
     """Run a single test"""
 
     def __init__(self, server_hostname, server_port, test_id,
-                 test_index, logger_name, log_dir, debug, fail_bad_cluster_utilization):
+                 test_index, logger_name, log_dir, debug, fail_bad_cluster_utilization, deflake_num):
         signal.signal(signal.SIGTERM, self._sigterm_handler)  # register a SIGTERM handler
 
         self.serde = SerDe()
@@ -57,6 +58,8 @@ class RunnerClient(object):
         self.session_context = ready_reply["session_context"]
         self.test_metadata = ready_reply["test_metadata"]
         self.cluster = ready_reply["cluster"]
+
+        self.deflake_num = deflake_num
 
         # Wait to instantiate the test object until running the test
         self.test = None
@@ -102,60 +105,64 @@ class RunnerClient(object):
 
         start_time = -1
         stop_time = -1
-        test_status = PASS
+        test_status = FAIL
         summary = ""
         data = None
 
-        try:
-            # Results from this test, as well as logs will be dumped here
-            mkdir_p(TestContext.results_dir(self.test_context, self.test_index))
-            # Instantiate test
-            self.test = self.test_context.cls(self.test_context)
+        num_runs = self.deflake_num
+        while test_status is FAIL or num_runs > 0:
+            num_runs -= 1
+            try:
+                # Results from this test, as well as logs will be dumped here
+                mkdir_p(TestContext.results_dir(self.test_context, self.test_index))
+                # Instantiate test
+                self.test = self.test_context.cls(self.test_context)
 
-            self.log(logging.DEBUG, "Checking if there are enough nodes...")
-            min_cluster_spec = self.test.min_cluster_spec()
-            os_to_num_nodes = {}
-            for node_spec in min_cluster_spec:
-                if not os_to_num_nodes.get(node_spec.operating_system):
-                    os_to_num_nodes[node_spec.operating_system] = 1
-                else:
-                    os_to_num_nodes[node_spec.operating_system] = os_to_num_nodes[node_spec.operating_system] + 1
-            for (operating_system, node_count) in iteritems(os_to_num_nodes):
-                num_avail = len(list(self.cluster.all().nodes.elements(operating_system=operating_system)))
-                if node_count > num_avail:
-                    raise RuntimeError(
-                        "There are not enough nodes available in the cluster to run this test. "
-                        "Cluster size for %s: %d, Need at least: %d. Services currently registered: %s" %
-                        (operating_system, num_avail, node_count, self.test_context.services))
+                self.log(logging.DEBUG, "Checking if there are enough nodes...")
+                min_cluster_spec = self.test.min_cluster_spec()
+                os_to_num_nodes = {}
+                for node_spec in min_cluster_spec:
+                    if not os_to_num_nodes.get(node_spec.operating_system):
+                        os_to_num_nodes[node_spec.operating_system] = 1
+                    else:
+                        os_to_num_nodes[node_spec.operating_system] = os_to_num_nodes[node_spec.operating_system] + 1
+                for (operating_system, node_count) in iteritems(os_to_num_nodes):
+                    num_avail = len(list(self.cluster.all().nodes.elements(operating_system=operating_system)))
+                    if node_count > num_avail:
+                        raise RuntimeError(
+                            "There are not enough nodes available in the cluster to run this test. "
+                            "Cluster size for %s: %d, Need at least: %d. Services currently registered: %s" %
+                            (operating_system, num_avail, node_count, self.test_context.services))
 
-            # Run the test unit
-            start_time = time.time()
-            self.setup_test()
+                # Run the test unit
+                start_time = time.time()
+                self.setup_test()
 
-            data = self.run_test()
+                data = self.run_test()
 
-            test_status = PASS
-            self.log(logging.INFO, "PASS")
+                test_status = PASS if num_runs == self.deflake_num else FLAKY
+                self.log(logging.INFO, "{} TEST".format(test_status.to_json))
 
-        except BaseException as e:
-            # mark the test as failed before doing anything else
-            test_status = FAIL
-            err_trace = self._exc_msg(e)
-            summary += err_trace
-            self.log(logging.INFO, "FAIL: " + err_trace)
+            except BaseException as e:
+                # mark the test as failed before doing anything else
+                test_status = FAIL
+                err_trace = self._exc_msg(e)
+                summary += err_trace
+                self.log(logging.INFO, "FAIL: " + err_trace)
 
-        finally:
-            self.teardown_test(teardown_services=not self.session_context.no_teardown, test_status=test_status)
+            finally:
+                self.teardown_test(teardown_services=not self.session_context.no_teardown, test_status=test_status)
 
-            stop_time = time.time()
+                stop_time = time.time()
 
-            if hasattr(self, "services"):
-                service_errors = self.test_context.services.errors()
-                if service_errors:
-                    summary += "\n\n" + service_errors
+                if hasattr(self, "services"):
+                    service_errors = self.test_context.services.errors()
+                    if service_errors:
+                        summary += "\n\n" + service_errors
 
-            test_status, summary = self._check_cluster_utilization(test_status, summary)
+                test_status, summary = self._check_cluster_utilization(test_status, summary)
 
+            # for flaky tests, we report the start and end time of the successfull run, and not the whole run period
             result = TestResult(
                 self.test_context,
                 self.test_index,

--- a/ducktape/tests/status.py
+++ b/ducktape/tests/status.py
@@ -28,5 +28,6 @@ class TestStatus(object):
 
 
 PASS = TestStatus("pass")
+FLAKY = TestStatus("flaky")
 FAIL = TestStatus("fail")
 IGNORE = TestStatus("ignore")

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,14 @@ class PyTest(TestCommand):
         self.run_command('flake8')
         sys.exit(errno)
 
+test_req = [
+    'pytest==4.6.5',
+    'mock==3.0.5',
+    'psutil==5.6.3',
+    'memory_profiler==0.55',
+    'statistics==1.0.3.5',
+    'requests-testadapter==0.3.0'
+]
 
 setup(name="ducktape",
       version=version,
@@ -64,12 +72,8 @@ setup(name="ducktape",
                         'filelock==3.2.1',
                         'cryptography==3.3.2'
                         ],
-      tests_require=['pytest==4.6.5',
-                     'mock==3.0.5',
-                     'psutil==5.6.3',
-                     'memory_profiler==0.55',
-                     'statistics==1.0.3.5',
-                     'requests-testadapter==0.3.0'],
+      tests_require=test_req,
+      extras_require={'test': test_req},
       setup_requires=['flake8==3.7.8'],
       cmdclass={'test': PyTest},
       )

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -428,6 +428,10 @@ class RemoteAccountTest(Test):
         self.account_service.start()
 
     @cluster(num_nodes=1)
+    def test_flaky(self):
+        assert random.choice([True, False, False])
+
+    @cluster(num_nodes=1)
     def test_ssh_capture_combine_stderr(self):
         """Test that ssh_capture correctly captures stderr and stdout from remote process.
         """

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     from mock import patch, MagicMock  # noqa: F401
 
+import sys
 from ducktape.tests.runner_client import RunnerClient
 from ducktape.tests.test import TestContext
 from ducktape.tests.runner import TestRunner
@@ -54,7 +55,7 @@ class CheckRunner(object):
 
         test_context = TestContext(session_context=session_context, module=None, cls=TestThingy,
                                    function=TestThingy.test_pi, file=TEST_THINGY_FILE, cluster=mock_cluster)
-        runner = TestRunner(mock_cluster, session_context, Mock(), [test_context])
+        runner = TestRunner(mock_cluster, session_context, Mock(), [test_context], 1)
 
         # Even though the cluster is too small, the test runner should this handle gracefully without raising an error
         results = runner.run_all_tests()
@@ -80,16 +81,34 @@ class CheckRunner(object):
         test_methods = [TestThingy.test_pi, TestThingy.test_ignore1, TestThingy.test_ignore2, TestThingy.test_failure]
         ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=TestThingy, test_methods=test_methods,
                                    cluster=mock_cluster, session_context=session_context)
-        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
 
         results = runner.run_all_tests()
         assert len(results) == 4
+        assert results.num_flaky == 0
         assert results.num_failed == 1
         assert results.num_passed == 1
         assert results.num_ignored == 2
 
         result_with_data = [r for r in results if r.data is not None][0]
         assert result_with_data.data == {"data": 3.14159}
+
+    def check_deflake_run(self):
+        """Check expected behavior when running a single test."""
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context()
+
+        test_methods = [TestThingy.test_flaky, TestThingy.test_failure]
+        ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=TestThingy, test_methods=test_methods,
+                                   cluster=mock_cluster, session_context=session_context)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 2)
+
+        results = runner.run_all_tests()
+        assert len(results) == 2
+        assert results.num_flaky == 1
+        assert results.num_failed == 1
+        assert results.num_passed == 0
+        assert results.num_ignored == 0
 
     def check_runner_report_junit(self):
         """Check we can serialize results into a xunit xml format. Also ensures that the XML report
@@ -99,7 +118,7 @@ class CheckRunner(object):
         test_methods = [TestThingy.test_pi, TestThingy.test_ignore1, TestThingy.test_ignore2, TestThingy.test_failure]
         ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=TestThingy, test_methods=test_methods,
                                    cluster=mock_cluster, session_context=session_context)
-        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
 
         results = runner.run_all_tests()
         JUnitReporter(results).report()
@@ -138,7 +157,7 @@ class CheckRunner(object):
         test_methods = [FailingTest.test_fail]
         ctx_list = self._do_expand(test_file=FAILING_TEST_FILE, test_class=FailingTest, test_methods=test_methods,
                                    cluster=mock_cluster, session_context=session_context)
-        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
         results = runner.run_all_tests()
         assert len(ctx_list) > 1
         assert len(results) == 1
@@ -156,10 +175,11 @@ class CheckRunner(object):
                                         test_methods=[FailsToInitInSetupTest.test_nothing],
                                         cluster=mock_cluster, session_context=session_context))
 
-        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
         results = runner.run_all_tests()
         # These tests fail to initialize, each class has two test methods, so should have 4 results, all failed
         assert len(results) == 4
+        assert results.num_flaky == 0
         assert results.num_failed == 4
         assert results.num_passed == 0
         assert results.num_ignored == 0
@@ -180,12 +200,13 @@ class CheckRunner(object):
         test_methods = [TestThingy.test_pi, TestThingy.test_ignore1, TestThingy.test_ignore2, TestThingy.test_failure]
         ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=TestThingy, test_methods=test_methods,
                                    cluster=mock_cluster, session_context=session_context)
-        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
 
         results = runner.run_all_tests()
         assert len(results) == 4
-        assert results.num_failed == 2
-        assert results.num_passed == 0
+        assert results.num_flaky == 0
+        assert results.num_failed == 1
+        assert results.num_passed == 1
         assert results.num_ignored == 2
 
     def check_run_failure_with_bad_cluster_allocation(self):
@@ -198,11 +219,12 @@ class CheckRunner(object):
         ctx_list = self._do_expand(test_file=TEST_THINGY_FILE, test_class=ClusterTestThingy,
                                    test_methods=test_methods, cluster=mock_cluster,
                                    session_context=session_context)
-        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list)
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
 
         results = runner.run_all_tests()
 
         assert len(results) == 2
+        assert results.num_flaky == 0
         assert results.num_failed == 1
         assert results.num_passed == 1
         assert results.num_ignored == 0

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -16,7 +16,6 @@ try:
 except ImportError:
     from mock import patch, MagicMock  # noqa: F401
 
-import sys
 from ducktape.tests.runner_client import RunnerClient
 from ducktape.tests.test import TestContext
 from ducktape.tests.runner import TestRunner

--- a/tests/runner/check_runner_memory.py
+++ b/tests/runner/check_runner_memory.py
@@ -87,7 +87,7 @@ class CheckMemoryUsage(object):
         assert len(ctx_list) == N_TEST_CASES  # Sanity check
 
         q = queue.Queue()
-        runner = InstrumentedTestRunner(self.cluster, self.session_context, Mock(), ctx_list, queue=q)
+        runner = InstrumentedTestRunner(self.cluster, self.session_context, Mock(), ctx_list, 1, queue=q)
         runner.run_all_tests()
 
         measurements = []

--- a/tests/runner/resources/test_thingy.py
+++ b/tests/runner/resources/test_thingy.py
@@ -18,6 +18,9 @@ from ducktape.mark import ignore, parametrize
 from ducktape.mark.resource import cluster
 
 
+_flake = False
+
+
 class TestThingy(Test):
     """Fake ducktape test class"""
 
@@ -25,7 +28,7 @@ class TestThingy(Test):
         """ This test uses many nodes, wow!"""
         return ClusterSpec.simple_linux(1000)
 
-    def test_pi(self):
+    def  test_pi(self):
         return {"data": 3.14159}
 
     @ignore
@@ -39,6 +42,11 @@ class TestThingy(Test):
 
     def test_failure(self):
         raise Exception("This failed")
+
+    def test_flaky(self):
+        global _flake
+        flake, _flake = _flake, not _flake
+        assert flake
 
 
 class ClusterTestThingy(Test):

--- a/tests/runner/resources/test_thingy.py
+++ b/tests/runner/resources/test_thingy.py
@@ -28,7 +28,7 @@ class TestThingy(Test):
         """ This test uses many nodes, wow!"""
         return ClusterSpec.simple_linux(1000)
 
-    def  test_pi(self):
+    def test_pi(self):
         return {"data": 3.14159}
 
     @ignore


### PR DESCRIPTION
This pr adds the ability to run ducktape with the flag `--deflake`.  This option allows a user to specify how many times a test can be reran once it fails to determine if the failure is flaky.  As an example if you run a ducktape test with `--deflake 5` and the test fails, it will run up to 5 times until it either passes (and will be then marked as flaky) or fail if it fails all deflake runs.
