### PR TITLE
wrap long stack trace lines

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     name = "ducktape" + i.to_s
     config.vm.define name do |worker|
       worker.vm.hostname = name
-      worker.vm.network :private_network, ip: "192.168.50." + (150 + i).to_s
+      worker.vm.network :private_network, ip: "192.168.56." + (150 + i).to_s
     end
   }
 

--- a/ducktape/templates/report/report.css
+++ b/ducktape/templates/report/report.css
@@ -33,6 +33,13 @@ h1, h2, h3, h4, h5, h6 {
     padding: 2px;
 }
 
+.pre_stack_trace {
+    white-space: pre-wrap;       /* Since CSS 2.1 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}
+
 .header_row {
     font-weight: bold;
     color: white;

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -87,7 +87,7 @@
               <td colSpan='5' align='center'><pre>{this.props.test.description}</pre></td>
               <td colSpan='5' align='center'><pre>{this.props.test.run_time}</pre></td>
               <td colSpan='5' align='center'><pre>{this.props.test.data}</pre></td>
-              <td colSpan='5' align='center'><pre>{this.props.test.summary}</pre></td>
+              <td colSpan='5' align='center'><pre className="pre_stack_trace">{this.props.test.summary}</pre></td>
               {detailCol}
             </tr>
           );


### PR DESCRIPTION
- wrap long stack trace lines:
![Screen Shot 2022-04-22 at 2 37 25 PM](https://user-images.githubusercontent.com/49661990/164799219-f5b058bc-833d-4591-9943-4e219690095d.png)

- update vagrantfile to work with latest virtualbox:
```
==> ducktape1: Clearing any previously set network interfaces...
The IP address configured for the host-only network is not within the
allowed ranges. Please update the address used to be within the allowed
ranges and run the command again.

  Address: 192.168.50.151
  Ranges: 192.168.56.0/21

Valid ranges can be modified in the /etc/vbox/networks.conf file. For
more information including valid format see:

  https://www.virtualbox.org/manual/ch06.html#network_hostonly

```