### PR TITLE
Print failed test specs

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -27,7 +27,7 @@ from ducktape.command_line.parse_args import parse_args
 from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.loggermaker import close_logger
 from ducktape.tests.reporter import SimpleStdoutSummaryReporter, SimpleFileSummaryReporter, \
-    HTMLSummaryReporter, JSONReporter, JUnitReporter
+    HTMLSummaryReporter, JSONReporter, JUnitReporter, TestSuiteGeneratorReporter
 from ducktape.tests.runner import TestRunner
 from ducktape.tests.session import SessionContext, SessionLoggerMaker
 from ducktape.tests.session import generate_session_id, generate_results_dir
@@ -188,7 +188,8 @@ def main():
         SimpleFileSummaryReporter(test_results),
         HTMLSummaryReporter(test_results),
         JSONReporter(test_results),
-        JUnitReporter(test_results)
+        JUnitReporter(test_results),
+        TestSuiteGeneratorReporter(test_results)
     ]
 
     for r in reporters:

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -27,7 +27,7 @@ from ducktape.command_line.parse_args import parse_args
 from ducktape.tests.loader import TestLoader, LoaderException
 from ducktape.tests.loggermaker import close_logger
 from ducktape.tests.reporter import SimpleStdoutSummaryReporter, SimpleFileSummaryReporter, \
-    HTMLSummaryReporter, JSONReporter, JUnitReporter, TestSuiteGeneratorReporter
+    HTMLSummaryReporter, JSONReporter, JUnitReporter, FailedTestSymbolReporter
 from ducktape.tests.runner import TestRunner
 from ducktape.tests.session import SessionContext, SessionLoggerMaker
 from ducktape.tests.session import generate_session_id, generate_results_dir
@@ -189,7 +189,7 @@ def main():
         HTMLSummaryReporter(test_results),
         JSONReporter(test_results),
         JUnitReporter(test_results),
-        TestSuiteGeneratorReporter(test_results)
+        FailedTestSymbolReporter(test_results)
     ]
 
     for r in reporters:

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -313,7 +313,7 @@ class TestSuiteGeneratorReporter(SummaryReporter):
 
     def __init__(self, results):
         super().__init__(results)
-        self.separator = ''.join(["=" * self.width])
+        self.separator = "=" * self.width
 
     def format_line(self, result):
         line = f'{result.file_name}::{result.cls_name}.{result.function_name}'

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -324,6 +324,7 @@ class TestSuiteGeneratorReporter(SummaryReporter):
 
     def dump_test_suite(self, lines):
         print(self.separator)
+        print('FAILED TEST SUITE')
         suite = {self.results.session_context.session_id: lines}
         file_path = Path(self.results.session_context.results_dir) / "rerun-failed.yml"
         with file_path.open('w') as fp:

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -346,4 +346,3 @@ class FailedTestSymbolReporter(SummaryReporter):
 
         self.dump_test_suite(symbols)
         self.print_test_symbols_string(symbols)
-

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -309,13 +309,14 @@ class HTMLSummaryReporter(SummaryReporter):
         self.format_report()
 
 
-class TestSuiteGeneratorReporter(SummaryReporter):
+class FailedTestSymbolReporter(SummaryReporter):
 
     def __init__(self, results):
         super().__init__(results)
         self.separator = "=" * self.width
 
-    def format_line(self, result):
+    @staticmethod
+    def to_symbol(result):
         line = f'{result.file_name}::{result.cls_name}.{result.function_name}'
         if result.injected_args:
             injected_args_str = json.dumps(result.injected_args, separators=(',', ':'))
@@ -331,17 +332,18 @@ class TestSuiteGeneratorReporter(SummaryReporter):
             print(f'Test suite to rerun failed tests: {file_path}')
             yaml.dump(suite, stream=fp, indent=4)
 
-    def print_test_string(self, lines):
+    def print_test_symbols_string(self, lines):
         print(self.separator)
         print('FAILED TEST SYMBOLS')
         print('Pass the test symbols below to your ducktape run')
+        # quote the symbol because json parameters will be processed by shell otherwise, making it not copy-pasteable
         print(' '.join([f"'{line}'" for line in lines]))
 
     def report(self):
-        lines = [self.format_line(result) for result in self.results if result.test_status == FAIL]
-        if not lines:
+        symbols = [self.to_symbol(result) for result in self.results if result.test_status == FAIL]
+        if not symbols:
             return
 
-        self.dump_test_suite(lines)
-        self.print_test_string(lines)
+        self.dump_test_suite(symbols)
+        self.print_test_symbols_string(symbols)
 

--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -64,6 +64,7 @@ class TestResult(object):
         self.test_status = test_status
         self.summary = summary
         self.data = data
+        self.file_name = test_context.file
 
         self.base_results_dir = session_context.results_dir
         if not self.results_dir.endswith(os.path.sep):

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -16,7 +16,7 @@ from ducktape.services.service import Service
 from ducktape.tests.test import Test
 from ducktape.errors import TimeoutError
 from ducktape.mark.resource import cluster
-from ducktape.mark import matrix, parametrize, ignore
+from ducktape.mark import matrix, parametrize
 
 import os
 import pytest

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -16,6 +16,7 @@ from ducktape.services.service import Service
 from ducktape.tests.test import Test
 from ducktape.errors import TimeoutError
 from ducktape.mark.resource import cluster
+from ducktape.mark import matrix, parametrize, ignore
 
 import os
 import pytest
@@ -108,6 +109,33 @@ class UnderUtilizedTest(Test):
         self.service.free()
         assert len(self.test_context.cluster.used()) == 1
         assert self.test_context.cluster.max_used() == 2
+
+
+class FailingTest(Test):
+    """
+    The purpose of this test is to validate reporters. Some of them are intended to fail.
+    """
+    def setup(self):
+        self.service = GenericService(self.test_context, 1)
+
+    @cluster(num_nodes=1)
+    @matrix(string_param=['success-first', 'fail-second', 'fail-third'], int_param=[10, 20, -30])
+    def matrix_test(self, string_param, int_param):
+        assert not string_param.startswith('fail') and int_param > 0
+
+    @cluster(num_nodes=1)
+    @parametrize(string_param=['success-first', 'fail-second'])
+    @parametrize(int_param=[10, -10])
+    def parametrized_test(self, string_param, int_param):
+        assert not string_param.startswith('fail') and int_param > 0
+
+    @cluster(num_nodes=1)
+    def failing_test(self):
+        assert False
+
+    @cluster(num_nodes=1)
+    def successful_test(self):
+        assert True
 
 
 class FileSystemTest(Test):

--- a/tests/reporter/check_symbol_reporter.py
+++ b/tests/reporter/check_symbol_reporter.py
@@ -1,7 +1,5 @@
 from unittest.mock import Mock
 
-import pytest
-
 from ducktape.tests.reporter import FailedTestSymbolReporter
 
 

--- a/tests/reporter/check_symbol_reporter.py
+++ b/tests/reporter/check_symbol_reporter.py
@@ -1,0 +1,19 @@
+from unittest.mock import Mock
+
+import pytest
+
+from ducktape.tests.reporter import FailedTestSymbolReporter
+
+
+def check_to_symbol_no_args():
+    result = Mock(file_name='test_folder/test_file', cls_name='TestClass', function_name='test_func',
+                  injected_args=None)
+
+    assert FailedTestSymbolReporter.to_symbol(result) == 'test_folder/test_file::TestClass.test_func'
+
+
+def check_to_symbol_with_args():
+    result = Mock(file_name='test_folder/test_file', cls_name='TestClass', function_name='test_func',
+                  injected_args={'arg': 'val'})
+
+    assert FailedTestSymbolReporter.to_symbol(result) == 'test_folder/test_file::TestClass.test_func@{"arg":"val"}'


### PR DESCRIPTION
This PR adds a reporter that prints failed test symbols (including any parametrize/matrix specs) to stdout, as well as generating a test suite yaml file.

Sample output:
```shell
====================================================================================================================================================================================================================================================================================================================================================================
FAILED TEST SUITE
Test suite to rerun failed tests: /Users/stanislav.vodetskyi/github/ducktape/results/2022-04-22--027/rerun-failed.yml
====================================================================================================================================================================================================================================================================================================================================================================
FAILED TEST SYMBOLS
Pass the test symbols below to your ducktape run
'/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.failing_test' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-second","int_param":-30}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-second","int_param":10}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-second","int_param":20}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-third","int_param":-30}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-third","int_param":10}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-third","int_param":20}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"success-first","int_param":-30}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.parametrized_test@{"int_param":[10,-10]}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.parametrized_test@{"string_param":["success-first","fail-second"]}'

```

You can then either do `ducktape results/latest/rerun-failed.yml` or copy the output from stdout and paste it directly as a ducktape argument:
```shell
ducktape '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.failing_test' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-second","int_param":-30}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-second","int_param":10}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-second","int_param":20}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-third","int_param":-30}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-third","int_param":10}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"fail-third","int_param":20}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.matrix_test@{"string_param":"success-first","int_param":-30}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.parametrized_test@{"int_param":[10,-10]}' '/Users/stanislav.vodetskyi/github/ducktape/systests/cluster/test_remote_account.py::FailingTest.parametrized_test@{"string_param":["success-first","fail-second"]}'

```

While not as powerful as a deflake feature by @imcdo , this one allows you to edit which ones you want to rerun prior to rerunning. Yet another option for debugging flakiness :)