### PR TITLE
Fix runner client

### DIFF
--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -83,10 +83,10 @@ def create_ducktape_parser():
                         "validation or better logging when an ssh error occurs. Specify any "
                         "number of module paths after this flag to be called."),
     parser.add_argument("--deflake", action="store", type=int, default=1,
-                        help=
-                        "the number of times a failed test should be ran total (including its initial run) to determin flakyness,"
-                        "when not present, deflake will not be used, and a test will be marked as either passed or failed, when enabled"
-                        "tests will be marked as flaky if it passes any of the reruns")
+                        help="the number of times a failed test should be ran in total (including its initial run) "
+                             "to determine flakyness. When not present, deflake will not be used, "
+                             "and a test will be marked as either passed or failed. "
+                             "When enabled tests will be marked as flaky if it passes on any of the reruns")
     return parser
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ class PyTest(TestCommand):
         self.run_command('flake8')
         sys.exit(errno)
 
+
 test_req = [
     'pytest==4.6.5',
     'mock==3.0.5',

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -204,8 +204,8 @@ class CheckRunner(object):
         results = runner.run_all_tests()
         assert len(results) == 4
         assert results.num_flaky == 0
-        assert results.num_failed == 1
-        assert results.num_passed == 1
+        assert results.num_failed == 2
+        assert results.num_passed == 0
         assert results.num_ignored == 2
 
     def check_run_failure_with_bad_cluster_allocation(self):


### PR DESCRIPTION
Deflake implementation moved try-except-finally check inside the loop - so if an exception happens when reporting another exception (inside `except BaseException`), inner `finally` block inside the loop will execute, but everything outside the loop won't - meaning runner_client will never report the results back.
This is a rare case, and it's unlikely to come up in real world, but it is possible.
Fixed by extracting a single test execution into a separate function, and wrapping a deflake loop in a try-finally. No need for except, we'll let the inner exception from the _do_run to bump through.
Also updated the unit test to how it was before deflake.