### PR TITLE
cleaner logging for a passing test

### DIFF
--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -125,7 +125,7 @@ class RunnerClient(object):
                 if test_status == PASS and num_runs > 1:
                     test_status = FLAKY
 
-                msg = "{}".format(test_status.to_json())
+                msg = str(test_status.to_json())
                 if summary:
                     msg += ": {}".format(summary)
                 if num_runs != self.deflake_num:

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -121,11 +121,21 @@ class RunnerClient(object):
                 self.log(logging.INFO, "on run {}/{}".format(num_runs, self.deflake_num))
                 start_time = time.time()
                 test_status, summary, data = self._do_run(num_runs)
+
+                if test_status == PASS and num_runs > 1:
+                    test_status = FLAKY
+
+                msg = "{}".format(test_status.to_json())
+                if summary:
+                    msg += ": {}".format(summary)
+                if num_runs != self.deflake_num:
+                    msg += "\n" + "~" * max(len(l) for l in summary.split('\n'))
+
+                self.log(logging.INFO, msg)
+
         finally:
             stop_time = time.time()
-            if test_status == PASS and num_runs > 1:
-                test_status = FLAKY
-            summary = "".join(summary)
+
             test_status, summary = self._check_cluster_utilization(test_status, summary)
 
             if num_runs > 1:
@@ -142,7 +152,6 @@ class RunnerClient(object):
                 start_time,
                 stop_time)
 
-            self.log(logging.INFO, "Summary: %s" % str(result.summary))
             self.log(logging.INFO, "Data: %s" % str(result.data))
 
             result.report()
@@ -175,17 +184,12 @@ class RunnerClient(object):
             data = self.run_test()
 
             test_status = PASS
-            # test_status.to_json() simply prints PASS - str(self).upper() - so might as well just print PASS directly
-            self.log(logging.INFO, "PASS")
 
         except BaseException as e:
             # mark the test as failed before doing anything else
             test_status = FAIL
             err_trace = self._exc_msg(e)
             summary.append(err_trace)
-            if num_runs != self.deflake_num:
-                summary.append("~" * max(len(l) for l in err_trace.split('\n')) + "\n")
-            self.log(logging.INFO, "FAIL: " + err_trace)
 
         finally:
             for service in self.test_context.services:
@@ -203,7 +207,7 @@ class RunnerClient(object):
             if self.test:
                 self.log(logging.DEBUG, "Freeing nodes...")
                 self._do_safely(self.test.free_nodes, "Error freeing nodes:")
-            return test_status, summary, data
+            return test_status, "".join(summary), data
 
     def _check_min_cluster_spec(self):
         self.log(logging.DEBUG, "Checking if there are enough nodes...")

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -175,7 +175,8 @@ class RunnerClient(object):
             data = self.run_test()
 
             test_status = PASS
-            self.log(logging.INFO, "{} TEST".format(test_status.to_json()))
+            # test_status.to_json() simply prints PASS - str(self).upper() - so might as well just print PASS directly
+            self.log(logging.INFO, "PASS")
 
         except BaseException as e:
             # mark the test as failed before doing anything else


### PR DESCRIPTION
We don't need the `TEST` bit; and we can simply print the string value rather than 'to_json' - because it evaluates to that string value anyway. If we wanted to future-proof this, we would change all the places where we print the status, but I don't think there's any point in doing so