### PR TITLE
update fetch_externally_routable_ips to use any network device

### DIFF
--- a/ducktape/cluster/linux_remoteaccount.py
+++ b/ducktape/cluster/linux_remoteaccount.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from deprecated import deprecated
 from ducktape.cluster.cluster_spec import LINUX
-from ducktape.cluster.remoteaccount import RemoteAccount
+from ducktape.cluster.remoteaccount import RemoteAccount, RemoteAccountError
 
 
 class LinuxRemoteAccount(RemoteAccount):
@@ -30,11 +31,37 @@ class LinuxRemoteAccount(RemoteAccount):
         This is an imperfect heuristic, but should work for simple local testing."""
         return self.hostname == "localhost" and self.user is None and self.ssh_config is None
 
-    def fetch_externally_routable_ip(self, is_aws):
-        if is_aws:
-            cmd = "/sbin/ifconfig eth0 "
-        else:
-            cmd = "/sbin/ifconfig eth1 "
-        cmd += r"| grep 'inet ' | tail -n 1 | egrep -o '[0-9\.]+' | head -n 1 2>&1"
-        output = "".join(self.ssh_capture(cmd))
-        return output.strip()
+    # deprecated, please just use the remove externally routable device
+    @deprecated
+    def fetch_externally_routable_ip(self, is_aws=None):
+        if is_aws is not None:
+            self.logger.warning("fetch_externally_routable_ip: is_aws is a depricated flag, and does nothing")
+
+        devices = [
+            device
+            for device in self.sftp_client.listdir('/sys/class/net')
+            if device != 'lo' # do not include local device
+        ]
+
+        self.logger.debug("found devices: {}".format(devices))
+
+        if len(devices) == 0:
+            raise RemoteAccountError("Couldn't find any network devices")
+
+        fmt_cmd = (
+            "/sbin/ifconfig {device} | " 
+            "grep 'inet ' | "
+            "tail -n 1 | "
+            r"egrep -o '[0-9\.]+' | "
+            "head -n 1 2>&1"
+        )
+
+        ips = [
+            "".join(
+                self.ssh_capture(fmt_cmd.format(device=device))
+            ).strip()
+            for device in devices
+        ]
+        self.logger.debug("found ips: {}".format(ips))
+        self.logger.debug("returning the first ip found")
+        return next(iter(ips))

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ six==1.12.0
 pynacl==1.4.0
 filelock==3.2.1
 cryptography==3.3.2
+Python-Deprecated~=1.1.0


### PR DESCRIPTION
instead of expecting a explicit network device, use a generic one based on the devices found on the remote machine.