### PR TITLE
updated vagrant to ubuntu 20 and fixed network discovery 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ VAGRANTFILE_API_VERSION = "2"
 enable_dns = false
 num_workers = 3
 ram_megabytes = 300
-base_box = "ubuntu/trusty64"
+base_box = "ubuntu/focal64"
 
 local_config_file = File.join(File.dirname(__FILE__), "Vagrantfile.local")
 if File.exists?(local_config_file) then

--- a/ducktape/cluster/linux_remoteaccount.py
+++ b/ducktape/cluster/linux_remoteaccount.py
@@ -47,7 +47,8 @@ class LinuxRemoteAccount(RemoteAccount):
             device
             for device in self.get_network_devices()
             if device != 'lo'  # do not include local device
-            and ("eth" in device or "ens" in device)  # filter out other devices
+            and (device.startswith("en") or device.startswith('eth'))  # filter out other devices; "en" means ethernet
+            # eth0 can also sometimes happen, see https://unix.stackexchange.com/q/134483
         ]
 
     # deprecated, please use the self.externally_routable_ip that is set in your cluster,


### PR DESCRIPTION
Updated vagrantfile to use ubuntu focal, rather than the ancient ubuntu 14
This required updating the network discovery code to account for other possible interface names, such as enp or enx.
See this stackexchange post - https://unix.stackexchange.com/q/134483
Tested by running ducktape systests on vagrant locally on a mac