### PR TITLE
Fail tests without non-empty @cluster annotation

### DIFF
--- a/ducktape/cluster/node_container.py
+++ b/ducktape/cluster/node_container.py
@@ -186,8 +186,15 @@ class NodeContainer(object):
         :returns:                               An empty string if we can remove the nodes;
                                                 an error string otherwise.
         """
-        if not cluster_spec:
-            return "cluster spec missing"
+        # if cluster_spec is None this means the test cannot be run at all
+        # e.g. users didn't specify `@cluster` annotation on it but the session context has a flag to fail
+        # on such tests or any other state where the test deems its cluster spec incorrect.
+        if cluster_spec is None:
+            return "Invalid or missing cluster spec"
+        # cluster spec may be empty and that's ok, shortcut to returning no error messages
+        elif len(cluster_spec) == 0:
+            return ""
+
         msg = ""
         for os, node_specs in iteritems(cluster_spec.nodes.os_to_nodes):
             num_nodes = len(node_specs)

--- a/ducktape/cluster/node_container.py
+++ b/ducktape/cluster/node_container.py
@@ -186,6 +186,8 @@ class NodeContainer(object):
         :returns:                               An empty string if we can remove the nodes;
                                                 an error string otherwise.
         """
+        if not cluster_spec:
+            return "cluster spec missing"
         msg = ""
         for os, node_specs in iteritems(cluster_spec.nodes.os_to_nodes):
             num_nodes = len(node_specs)

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -82,7 +82,9 @@ def create_ducktape_parser():
                         help="Fail a test if the cluster node utilization does not match the cluster node usage.")
     parser.add_argument("--fail-greedy-tests", action="store_true",
                         help="Fail a test if it has no @cluster annotation "
-                             "or if @cluster annotation is empty (or 0 nodes)")
+                             "or if @cluster annotation is empty. "
+                             "You can still specify 0-sized cluster explicitly using either num_nodes=0 "
+                             "or cluster_spec=ClusterSpec.empty()")
     parser.add_argument("--test-runner-timeout", action="store", type=int, default=1800000,
                         help="Amount of time in milliseconds between test communicating between the test runner"
                              " before a timeout error occurs. Default is 30 minutes")

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -80,6 +80,9 @@ def create_ducktape_parser():
                         help="The size of a random test sample to run")
     parser.add_argument("--fail-bad-cluster-utilization", action="store_true",
                         help="Fail a test if the cluster node utilization does not match the cluster node usage.")
+    parser.add_argument("--fail-greedy-tests", action="store_true",
+                        help="Fail a test if it has no @cluster annotation "
+                             "or if @cluster annotation is empty (or 0 nodes)")
     parser.add_argument("--test-runner-timeout", action="store", type=int, default=1800000,
                         help="Amount of time in milliseconds between test communicating between the test runner"
                              " before a timeout error occurs. Default is 30 minutes")

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -79,7 +79,9 @@ def create_ducktape_parser():
     parser.add_argument("--sample", action="store", type=int,
                         help="The size of a random test sample to run")
     parser.add_argument("--fail-bad-cluster-utilization", action="store_true",
-                        help="Fail a test if the cluster node utilization does not match the cluster node usage.")
+                        help="Fail a test if the test declared that it needs more nodes than it actually used. "
+                             "E.g. if the test had `@cluster(num_nodes=10)` annotation, "
+                             "but never used more than 5 nodes during its execution.")
     parser.add_argument("--fail-greedy-tests", action="store_true",
                         help="Fail a test if it has no @cluster annotation "
                              "or if @cluster annotation is empty. "

--- a/ducktape/mark/resource.py
+++ b/ducktape/mark/resource.py
@@ -44,6 +44,10 @@ class ClusterUseMetadata(Mark):
 def cluster(**kwargs):
     """Test method decorator used to provide hints about how the test will use the given cluster.
 
+    If this decorator is not provided, the test will either claim all cluster resources or fail immediately,
+    depending on the flags passed to ducktape.
+
+
     :Keywords used by ducktape:
 
         - ``num_nodes`` provide hint about how many nodes the test will consume

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -87,16 +87,6 @@ class ServiceRegistry(object):
         self._services.clear()
         self._nodes.clear()
 
-    def min_cluster_spec(self):
-        """
-        Returns the minimum cluster specification that would be required to run all the currently
-        extant services.
-        """
-        cluster_spec = ClusterSpec()
-        for service in self._services.values():
-            cluster_spec.add(service.cluster_spec)
-        return cluster_spec
-
     def errors(self):
         """
         Gets a printable string containing any errors produced by the services.

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -15,8 +15,6 @@
 
 from collections import OrderedDict
 
-from ducktape.cluster.cluster_spec import ClusterSpec
-
 
 class ServiceRegistry(object):
 

--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -43,12 +43,11 @@ class TestResult(object):
         @param data          data returned by the test, e.g. throughput
         """
         self.nodes_allocated = len(test_context.cluster)
+        self.nodes_used = test_context.cluster.max_used_nodes
         if hasattr(test_context, "services"):
             self.services = test_context.services.to_json()
-            self.nodes_used = test_context.services.min_cluster_spec().size()
         else:
             self.services = {}
-            self.nodes_used = 0
 
         self.test_id = test_context.test_id
         self.module_name = test_context.module_name

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -19,7 +19,6 @@ import time
 import traceback
 import zmq
 
-from six import iteritems
 from ducktape.services.service import MultiRunServiceIdFactory, service_id_factory
 from ducktape.services.service_registry import ServiceRegistry
 

--- a/ducktape/tests/scheduler.py
+++ b/ducktape/tests/scheduler.py
@@ -55,10 +55,12 @@ class TestScheduler(object):
 
         Sort from largest cluster users to smallest
         """
-        # sort from largest cluster users to smallest
-        self._test_context_list = sorted(self._test_context_list,
-                                         key=lambda tc: tc.expected_num_nodes,
-                                         reverse=True)
+        # sort from the largest cluster users to smallest
+        self._test_context_list = sorted(
+            self._test_context_list,
+            key=lambda tc: tc.expected_num_nodes,
+            reverse=True
+        )
 
     def peek(self):
         """Locate and return the next object to be scheduled, without removing it internally.

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -38,6 +38,7 @@ class SessionContext(object):
         self.max_parallel = kwargs.get("max_parallel", 1)
         self.default_expected_num_nodes = kwargs.get("default_num_nodes", None)
         self.fail_bad_cluster_utilization = kwargs.get("fail_bad_cluster_utilization")
+        self.fail_greedy_tests = kwargs.get("fail_greedy_tests", False)
         self.test_runner_timeout = kwargs.get("test_runner_timeout")
         self._globals = kwargs.get("globals")
 

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -23,6 +23,7 @@ import tempfile
 
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.tests.loggermaker import LoggerMaker, close_logger
+from ducktape.tests.session import SessionContext
 from ducktape.utils.local_filesystem_utils import mkdir_p
 from ducktape.command_line.defaults import ConsoleDefaults
 from ducktape.services.service_registry import ServiceRegistry
@@ -257,7 +258,7 @@ class TestContext(object):
         :param cluster_use_metadata: dict containing information about how this test will use cluster resources
         """
 
-        self.session_context = kwargs.get("session_context")
+        self.session_context: SessionContext = kwargs.get("session_context")
         self.cluster = kwargs.get("cluster")
         self.module = kwargs.get("module")
         self.test_suite_name = kwargs.get("test_suite_name")
@@ -360,8 +361,10 @@ class TestContext(object):
             return cluster_spec
         elif cluster_size is not None:
             return ClusterSpec.simple_linux(cluster_size)
-        else:
+        elif not self.cluster or self.session_context.fail_greedy_tests:
             return ClusterSpec.empty()
+        else:
+            return self.cluster.all()
 
     @property
     def globals(self):

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -50,40 +50,6 @@ class Test(TemplateRenderer):
     def logger(self):
         return self.test_context.logger
 
-    def min_cluster_spec(self):
-        """
-        Returns a specification for the minimal cluster we need to run this test.
-
-        This method replaces the deprecated min_cluster_size.  Unlike min_cluster_size, it can handle
-        non-Linux operating systems.
-
-        In general, most Tests don't need to override this method.  The default implementation
-        seen here works well in most cases.  However, the default implementation only takes into account
-        the services that exist at the time of the call.  You may need to override this method if you add
-        new services during the course of your test.
-
-        :return:            A ClusterSpec object.
-        """
-        try:
-            # If the Test overrode the deprecated min_cluster_size method, we will use that.
-            num_linux_nodes = self.min_cluster_size()
-            return ClusterSpec.simple_linux(num_linux_nodes)
-        except NotImplementedError:
-            # Otherwise, ask the service registry what kind of cluster spec we need for currently
-            # extant services.
-            return self.test_context.services.min_cluster_spec()
-
-    def min_cluster_size(self):
-        """
-        Returns the number of linux nodes which this test needs.
-
-        THIS METHOD IS DEPRECATED, and provided only for backwards compatibility.
-        Please implement min_cluster_spec instead.
-
-        :return:            An integer.
-        """
-        raise NotImplementedError
-
     def setup(self):
         """Override this for custom setup logic."""
 
@@ -394,10 +360,8 @@ class TestContext(object):
             return cluster_spec
         elif cluster_size is not None:
             return ClusterSpec.simple_linux(cluster_size)
-        elif self.cluster is None:
-            return ClusterSpec.empty()
         else:
-            return self.cluster.all()
+            return ClusterSpec.empty()
 
     @property
     def globals(self):

--- a/ducktape/tests/test.py
+++ b/ducktape/tests/test.py
@@ -51,6 +51,22 @@ class Test(TemplateRenderer):
     def logger(self):
         return self.test_context.logger
 
+    def min_cluster_spec(self):
+        """
+        THIS METHOD IS DEPRECATED AND WILL BE REMOVED IN THE SUBSEQUENT RELEASES.
+        Nothing in the ducktape framework calls it, it is only provided so that subclasses don't break.
+        If you're overriding this method in your subclass, please remove it.
+        """
+        raise NotImplementedError
+
+    def min_cluster_size(self):
+        """
+        THIS METHOD IS DEPRECATED AND WILL BE REMOVED IN THE SUBSEQUENT RELEASES.
+        Nothing in the ducktape framework calls it, it is only provided so that subclasses don't break.
+        If you're overriding this method in your subclass, please remove it.
+        """
+        raise NotImplementedError
+
     def setup(self):
         """Override this for custom setup logic."""
 

--- a/systests/cluster/test_no_cluster.py
+++ b/systests/cluster/test_no_cluster.py
@@ -1,0 +1,11 @@
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+
+
+class NoClusterTest(Test):
+    """This test helps validate the behavior for no-cluster tests (ie 0 nodes)"""
+
+    @cluster(num_nodes=0)
+    def test_zero_nodes(self):
+        self.logger.warn('Testing')
+        assert True

--- a/tests/cluster/check_node_container.py
+++ b/tests/cluster/check_node_container.py
@@ -215,7 +215,18 @@ class CheckNodeContainer(object):
         accounts = [fake_account('host1'), fake_account('host2'), fake_account('host3')]
         container = NodeContainer(accounts)
         spec = ClusterSpec.empty()
+        assert not container.attempt_remove_spec(spec)
+        assert container.can_remove_spec(spec)
+        good, bad = container.remove_spec(spec)
+        assert not good
+        assert not bad
+
+    def check_none_cluster_spec(self):
+        accounts = [fake_account('host1'), fake_account('host2'), fake_account('host3')]
+        container = NodeContainer(accounts)
+        spec = None
         assert container.attempt_remove_spec(spec)
         assert not container.can_remove_spec(spec)
         with pytest.raises(InsufficientResourcesError):
             container.remove_spec(spec)
+

--- a/tests/cluster/check_node_container.py
+++ b/tests/cluster/check_node_container.py
@@ -229,4 +229,3 @@ class CheckNodeContainer(object):
         assert not container.can_remove_spec(spec)
         with pytest.raises(InsufficientResourcesError):
             container.remove_spec(spec)
-

--- a/tests/cluster/check_node_container.py
+++ b/tests/cluster/check_node_container.py
@@ -210,3 +210,12 @@ class CheckNodeContainer(object):
         assert len(actual_linux) == 2
         actual_win = [node for node in good_nodes if node.os == WINDOWS]
         assert len(actual_win) == 2
+
+    def check_empty_cluster_spec(self):
+        accounts = [fake_account('host1'), fake_account('host2'), fake_account('host3')]
+        container = NodeContainer(accounts)
+        spec = ClusterSpec.empty()
+        assert container.attempt_remove_spec(spec)
+        assert not container.can_remove_spec(spec)
+        with pytest.raises(InsufficientResourcesError):
+            container.remove_spec(spec)

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -22,7 +22,7 @@ import pytest
 
 
 class CheckClusterUseAnnotation(object):
-
+    # TODO: review these tests
     def check_basic_usage_arbitrary_metadata(self):
         cluster_use_metadata = {
             'a': 2,

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import Mock
 
-
+from ducktape.cluster import LocalhostCluster
 from ducktape.mark import parametrize, matrix, ignore, defaults
 from ducktape.mark.mark_expander import MarkedFunctionExpander
 from ducktape.mark.resource import cluster
@@ -20,9 +21,11 @@ from ducktape.cluster.cluster_spec import ClusterSpec
 
 import pytest
 
+from tests import ducktape_mock
+
 
 class CheckClusterUseAnnotation(object):
-    # TODO: review these tests
+
     def check_basic_usage_arbitrary_metadata(self):
         cluster_use_metadata = {
             'a': 2,
@@ -64,22 +67,49 @@ class CheckClusterUseAnnotation(object):
         assert len(test_context_list) == 1
         assert test_context_list[0].expected_num_nodes == num_nodes
 
-    def check_empty_cluster_annotation(self):
+    @pytest.mark.parametrize('fail_greedy_tests', [True, False])
+    @pytest.mark.parametrize('has_annotation', [True, False])
+    def check_empty_cluster_annotation(self, fail_greedy_tests, has_annotation):
+
         @cluster()
+        def function_with_annotation():
+            return "hi"
+
+        def function_no_annotation():
+            return "hello"
+
+        assert hasattr(function_with_annotation, "marks")
+        assert not hasattr(function_no_annotation, "marks")
+
+        # no annotation and empty annotation behave identically as far as this functionality is concerned
+        function = function_with_annotation if has_annotation else function_no_annotation
+
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = ducktape_mock.session_context(fail_greedy_tests=fail_greedy_tests)
+        tc_list = MarkedFunctionExpander(function=function, cluster=mock_cluster, session_context=session_context).expand()
+
+        assert len(tc_list) == 1
+        if fail_greedy_tests:
+            assert tc_list[0].expected_num_nodes == 0
+            assert tc_list[0].expected_cluster_spec is None
+        else:
+            assert tc_list[0].expected_num_nodes == 1000
+
+    @pytest.mark.parametrize('fail_greedy_tests', [True, False])
+    def check_zero_nodes_annotation(self, fail_greedy_tests):
+        @cluster(num_nodes=0)
         def function():
             return "hi"
 
         assert hasattr(function, "marks")
-
-        tc_list = MarkedFunctionExpander(function=function).expand()
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = ducktape_mock.session_context(fail_greedy_tests=fail_greedy_tests)
+        tc_list = MarkedFunctionExpander(function=function, cluster=mock_cluster,
+                                         session_context=session_context).expand()
+        assert len(tc_list) == 1
         assert tc_list[0].expected_num_nodes == 0
-
-    def check_no_cluster_annotation(self):
-        def function():
-            return "hi"
-
-        tc_list = MarkedFunctionExpander(function=function).expand()
-        assert tc_list[0].expected_num_nodes == 0
+        assert tc_list[0].expected_cluster_spec is not None
+        assert len(tc_list[0].expected_cluster_spec) == 0
 
     def check_with_parametrize(self):
         num_nodes = 200

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import Mock
 
 from ducktape.cluster import LocalhostCluster
 from ducktape.mark import parametrize, matrix, ignore, defaults
@@ -86,7 +85,8 @@ class CheckClusterUseAnnotation(object):
 
         mock_cluster = LocalhostCluster(num_nodes=1000)
         session_context = ducktape_mock.session_context(fail_greedy_tests=fail_greedy_tests)
-        tc_list = MarkedFunctionExpander(function=function, cluster=mock_cluster, session_context=session_context).expand()
+        tc_list = MarkedFunctionExpander(
+            function=function, cluster=mock_cluster, session_context=session_context).expand()
 
         assert len(tc_list) == 1
         if fail_greedy_tests:

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -64,6 +64,23 @@ class CheckClusterUseAnnotation(object):
         assert len(test_context_list) == 1
         assert test_context_list[0].expected_num_nodes == num_nodes
 
+    def check_empty_cluster_annotation(self):
+        @cluster()
+        def function():
+            return "hi"
+
+        assert hasattr(function, "marks")
+
+        tc_list = MarkedFunctionExpander(function=function).expand()
+        assert tc_list[0].expected_num_nodes == 0
+
+    def check_no_cluster_annotation(self):
+        def function():
+            return "hi"
+
+        tc_list = MarkedFunctionExpander(function=function).expand()
+        assert tc_list[0].expected_num_nodes == 0
+
     def check_with_parametrize(self):
         num_nodes = 200
 

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -268,13 +268,14 @@ class CheckRunner(object):
         assert not runner._client_procs
 
     @pytest.mark.parametrize('fail_greedy_tests', [True, False])
-    def check_fail_if_no_cluster_annotation(self, fail_greedy_tests):
+    def check_fail_greedy_tests(self, fail_greedy_tests):
         mock_cluster = LocalhostCluster(num_nodes=1000)
         session_context = tests.ducktape_mock.session_context(fail_greedy_tests=fail_greedy_tests)
 
         test_methods = [
             VariousNumNodesTest.test_empty_cluster_annotation,
-            VariousNumNodesTest.test_no_cluster_annotation
+            VariousNumNodesTest.test_no_cluster_annotation,
+            VariousNumNodesTest.test_zero_nodes
         ]
         ctx_list = self._do_expand(test_file=VARIOUS_NUM_NODES_TEST_FILE, test_class=VariousNumNodesTest,
                                    test_methods=test_methods,
@@ -283,7 +284,8 @@ class CheckRunner(object):
         results = runner.run_all_tests()
         assert results.num_flaky == 0
         assert results.num_failed == (2 if fail_greedy_tests else 0)
-        assert results.num_passed == (0 if fail_greedy_tests else 2)
+        # zero-node test should always pass, whether we fail on greedy or not
+        assert results.num_passed == (1 if fail_greedy_tests else 3)
         assert results.num_ignored == 0
 
     def check_cluster_shrink(self):

--- a/tests/runner/resources/test_failing_tests.py
+++ b/tests/runner/resources/test_failing_tests.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+from ducktape.mark.resource import cluster
 from ducktape.tests.test import Test
 from ducktape.mark import matrix
 
@@ -24,6 +25,7 @@ class FailingTest(Test):
     def __init__(self, test_context):
         super(FailingTest, self).__init__(test_context)
 
+    @cluster(num_nodes=1000)
     @matrix(x=[_ for _ in range(2)])
     def test_fail(self, x):
         print("Test %s fails!" % x)

--- a/tests/runner/resources/test_memory_leak.py
+++ b/tests/runner/resources/test_memory_leak.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from ducktape.mark.resource import cluster
 from ducktape.tests.test import Test
 from ducktape.services.service import Service
 from ducktape.mark import matrix
@@ -51,6 +51,7 @@ class MemoryLeakTest(Test):
         super(MemoryLeakTest, self).__init__(test_context)
         self.memory_eater = MemoryEater(test_context)
 
+    @cluster(num_nodes=100)
     @matrix(x=[i for i in range(N_TEST_CASES)])
     def test_leak(self, x):
         self.memory_eater.start()

--- a/tests/runner/resources/test_thingy.py
+++ b/tests/runner/resources/test_thingy.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import time
-from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.tests.test import Test
 from ducktape.mark import ignore, parametrize
 from ducktape.mark.resource import cluster
@@ -61,4 +60,3 @@ class ClusterTestThingy(Test):
     @cluster(num_nodes=10)
     def test_bad_num_nodes(self):
         pass
-

--- a/tests/runner/resources/test_thingy.py
+++ b/tests/runner/resources/test_thingy.py
@@ -25,28 +25,30 @@ _flake = False
 class TestThingy(Test):
     """Fake ducktape test class"""
 
-    def min_cluster_spec(self):
-        """ This test uses many nodes, wow!"""
-        return ClusterSpec.simple_linux(1000)
-
+    @cluster(num_nodes=1000)
     def test_pi(self):
         return {"data": 3.14159}
 
+    @cluster(num_nodes=1000)
     def test_delayed(self):
         time.sleep(1)
 
+    @cluster(num_nodes=1000)
     @ignore
     def test_ignore1(self):
         pass
 
+    @cluster(num_nodes=1000)
     @ignore(x=5)
     @parametrize(x=5)
     def test_ignore2(self, x=2):
         pass
 
+    @cluster(num_nodes=1000)
     def test_failure(self):
         raise Exception("This failed")
 
+    @cluster(num_nodes=1000)
     def test_flaky(self):
         global _flake
         flake, _flake = _flake, not _flake
@@ -60,6 +62,3 @@ class ClusterTestThingy(Test):
     def test_bad_num_nodes(self):
         pass
 
-    @cluster(num_nodes=0)
-    def test_good_num_nodes(self):
-        pass

--- a/tests/runner/resources/test_various_num_nodes.py
+++ b/tests/runner/resources/test_various_num_nodes.py
@@ -49,3 +49,10 @@ class VariousNumNodesTest(Test):
     @cluster(num_nodes=1)
     def test_one_node_b(self):
         assert True
+
+    def test_no_cluster_annotation(self):
+        assert True
+
+    @cluster()
+    def test_empty_cluster_annotation(self):
+        assert True

--- a/tests/runner/resources/test_various_num_nodes.py
+++ b/tests/runner/resources/test_various_num_nodes.py
@@ -56,3 +56,10 @@ class VariousNumNodesTest(Test):
     @cluster()
     def test_empty_cluster_annotation(self):
         assert True
+
+    # this one is valid regardless of
+    # whether the greedy tests are allowed or not
+    # because it's not greedy, quite the opposite
+    @cluster(num_nodes=0)
+    def test_zero_nodes(self):
+        assert True


### PR DESCRIPTION
**This might be breaking change if you rely on min_cluster_spec() method and also two changes in one.**

**1. Deprecation of `min_cluster_spec()` method**
Turns out we have two different mechanisms to state expected number of nodes for the test - there's the `@cluster` annotation, which we know and love/hate, and min_cluster_spec method on the test object itself. They are not related, and we mostly use `@cluster` annotation, except for a single place where we check `min_cluster_spec` and possibly fail - however, this check makes no sense, because it has already been checked against `@cluster` annotation, plus the test would fail if it tries to allocated too many nodes anyway.

So I'm deprecating `min_cluster_spec` method, removing all its two usages (the second one is for reporting, and it's also inaccurate). The method is still there, so if clients override it and refer to super() they should still be ok. They would probably be ok even if I remove it, since python is interpreted and if nothing calls that method, it's probably fine, but it's cleaner and more obvious this way.

**2. Option to fail tests that don't explicitly specify their cluster requirements**
**The real functionality** of this PR is disallowing the tests that don't have `@cluster` annotation (or have them empty) and failing them immediately - since `@cluster` annotation is our preferred way of doing things right now, and since this protects us against tests that automatically use the whole cluster. 
This behavior is controlled by a **new flag - --fail-greedy-tests**, which enables this behavior when provided. We've discussed making this behavior automatic when using `--parallel` but ultimately felt that such behavior will be surprising for users, and not in a good way. We're still open to do this in the future, just not in this PR.

This PR also explicitly allows (and tests for) empty cluster spec in `@cluster()` annotation (e.g. `@cluster(num_nodes=0)`), thus allowing tests that don't use any cluster resources. This functionality was working fine before this PR, but didn't have unit tests, so we've made sure it still works after this PR.
