### PR TITLE
build docs with tox

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,35 @@
 Ducktape documentation quick start guide
 ========================================
 
-This file provides a quick guide on how to compile the Ducktape documentation.
-
-
-Setup the environment
----------------------
-
-To compile the documentation you need Sphinx Python library. To install it and all its dependencies run::
-
-    pip install -r requirements.txt
-
 
 Build the documentation
 -----------------------
 
 To render the pages run::
-
-    make html
+```shell
+tox -e docs
+```
     
 The rendered pages will be in ``docs/_build/html``
+
+
+Specify documentation format
+----------------------------
+
+Documentation is built using [sphinx-build](https://www.sphinx-doc.org/en/master/man/sphinx-build.html) command.
+You can select which builder to use using SPHINX_BUILDER command:
+```shell
+SPHINX_BUILDER=man tox -e docs
+```
+All available values: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-M
+
+
+Pass options to sphinx-build
+----------------------------
+Any argument after `--` will be passed to the 
+[sphinx-build](https://www.sphinx-doc.org/en/master/man/sphinx-build.html) command directly:
+```shell
+tox -e docs -- -E
+```
+
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,5 @@ sphinx-rtd-theme==0.2.4
 boto3==1.9.0
 pycryptodome==3.7.0
 pywinrm==0.2.2
+jinja2==2.11.2
+MarkupSafe<2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, cover, style
+envlist = py27, py36, py37, cover, style, docs
 
 [testenv]
 # Consolidate all deps here instead of separately in test/style/cover so we
@@ -41,6 +41,14 @@ envdir = {homedir}/.virtualenvs/ducktape
 commands =
     pytest {env:PYTESTARGS:} --cov ducktape --cov-report=xml --cov-report=html --cov-report=term --cov-report=annotate:textcov \
                              --cov-fail-under=70
+
+[testenv:docs]
+basepython = python3.7
+deps =
+    -r {toxinidir}/docs/requirements.txt
+changedir = {toxinidir}/docs
+commands = sphinx-build -M {env:SPHINX_BUILDER:html} . _build  {posargs}
+
 
 [flake8]
 exclude = .git,.tox,.eggs,__pycache__,docs,build,dist


### PR DESCRIPTION
Add a `docs` target to tox.ini.
This makes it easier to build the docs, and also would verify the docs can actually build on every PR.