### PR TITLE
Fix readthedocs config for 0.8.x

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,5 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .


### PR DESCRIPTION
Right now readthedocs is missing the documentation for the latest 0.8.x and 0.9.x releases. 0.10.x has this fix already, need to push this fix to older branches to make sure they don't break when readthedocs is trying to build them.