### PR TITLE
Removed tox dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,5 @@ paramiko~=2.7.2
 pyzmq==19.0.2
 pycryptodome==3.9.8
 more-itertools==5.0.0
-tox==3.20.0
 six==1.15.0
 PyYAML==5.3.1


### PR DESCRIPTION
It's not used anywhere, but it now breaks package installation on python 3.7.
I'm going to use admin permissions to merge this PR without reviews due to a relatively low risk and a relatively high impact.