### PR TITLE
Add debugging for hung tests

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -66,10 +66,12 @@ class Receiver(object):
             # use default value of 1800000 or 30 minutes
             timeout = 1800000
         self.socket.RCVTIMEO = timeout
+        t_0 = time.time()
         try:
             message = self.socket.recv()
         except zmq.Again:
-            raise TimeoutError("runner client unresponsive")
+            t_x = time.time()
+            raise TimeoutError(f"runner client unresponsive after {t_x - t_0:.2f} seconds.")
         return self.serde.deserialize(message)
 
     def send(self, event):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -255,9 +255,6 @@ class TestRunner(object):
                         self._log(logging.ERROR, err_str)
 
                         # All processes are on the same machine, so treat communication failure as a fatal error
-                        for proc in self._client_procs.values():
-                            proc.terminate()
-                        self._client_procs = {}
                         raise
             except KeyboardInterrupt:
                 # If SIGINT is received, stop triggering new tests, and let the currently running tests finish

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -38,6 +38,8 @@ from ducktape.errors import TimeoutError
 
 
 class Receiver(object):
+    LINGER_MS = 500
+
     def __init__(self, min_port, max_port):
         assert min_port <= max_port, "Expected min_port <= max_port, but instead: min_port: %s, max_port %s" % \
                                      (min_port, max_port)
@@ -49,6 +51,8 @@ class Receiver(object):
 
         self.zmq_context = zmq.Context()
         self.socket = self.zmq_context.socket(zmq.REP)
+        # Set a reasonable linger time to help with unclean shutdown
+        self.socket.setsockopt(zmq.LINGER, self.LINGER_MS)
 
     def start(self):
         """Bind to a random port in the range [self.min_port, self.max_port], inclusive
@@ -72,7 +76,6 @@ class Receiver(object):
         self.socket.send(self.serde.serialize(event))
 
     def close(self):
-        self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.close()
 
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -19,7 +19,6 @@ import multiprocessing
 import os
 import signal
 import time
-import traceback
 import zmq
 
 from ducktape.cluster.node_container import InsufficientResourcesError
@@ -118,7 +117,8 @@ class TestRunner(object):
         # This immutable dict tracks test_id -> test_context
         self._test_context = persistence.make_dict(**{t.test_id: t for t in tests})
         self._test_cluster = {}  # Track subcluster assigned to a particular TestKey
-        self._client_procs = {}  # track client processes running tests
+        # track client processes running tests
+        self._client_procs: dict[str, multiprocessing.Process] = {}
         self.active_tests = {}
         self.finished_tests = {}
         self.test_schedule_log = []
@@ -234,7 +234,8 @@ class TestRunner(object):
                         self._handle(event)
                     except Exception as e:
                         err_str = "Exception receiving message: %s: %s" % (str(type(e)), str(e))
-                        err_str += "\n" + traceback.format_exc(limit=16)
+                        # this is redundant output
+                        # err_str += "\n" + traceback.format_exc(limit=16)
                         self._log(logging.ERROR, err_str)
 
                         # All processes are on the same machine, so treat communication failure as a fatal error

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -17,7 +17,9 @@ import os
 import signal
 import time
 import traceback
+from typing import Optional
 import zmq
+from zmq import Socket
 
 from ducktape.services.service import MultiRunServiceIdFactory, service_id_factory
 from ducktape.services.service_registry import ServiceRegistry
@@ -301,7 +303,7 @@ class Sender(object):
         self.serde = SerDe()
         self.server_endpoint = "tcp://%s:%s" % (str(server_host), str(server_port))
         self.zmq_context = zmq.Context()
-        self.socket = None
+        self.socket: Optional[Socket] = None
         self.poller = zmq.Poller()
 
         self.message_supplier = message_supplier

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -294,7 +294,7 @@ class RunnerClient(object):
 
 
 class Sender(object):
-    REQUEST_TIMEOUT_MS = 3000
+    REQUEST_TIMEOUT_MS = 1000
     NUM_RETRIES = 5
 
     def __init__(self, server_host, server_port, message_supplier, logger):
@@ -311,6 +311,9 @@ class Sender(object):
 
     def _init_socket(self):
         self.socket = self.zmq_context.socket(zmq.REQ)
+        # Should be able to send immediately
+        self.socket.setsockopt(zmq.SNDTIMEO, self.REQUEST_TIMEOUT_MS)
+
         self.socket.connect(self.server_endpoint)
         self.poller.register(self.socket, zmq.POLLIN)
 

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import faulthandler
 import logging
 import os
 import signal
@@ -45,6 +46,8 @@ class RunnerClient(object):
     def __init__(self, server_hostname, server_port, test_id,
                  test_index, logger_name, log_dir, debug, fail_bad_cluster_utilization, deflake_num):
         signal.signal(signal.SIGTERM, self._sigterm_handler)  # register a SIGTERM handler
+        # for debugging stuck processes
+        faulthandler.register(signal.SIGUSR1)
 
         self.serde = SerDe()
         self.logger = test_logger(logger_name, log_dir, debug)


### PR DESCRIPTION
To allow us to debug hard-to-reproduce "hung test" failures, this PR adds special handling of test timeouts which, for any still-running child processes:

- Sends a SIGUSR1 which causes them to print stack traces of all
threads.
- Sends a SIGINT and wait for children processes to exit.

The goals are to provide diagnostics on where child test clients are stuck, and to allow the ducktape processes to exit, which should allow gathering logs.