### PR TITLE
Store summary of previous runs when deflaking

### DIFF
--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -27,7 +27,7 @@ from ducktape.services.service_registry import ServiceRegistry
 from ducktape.tests.event import ClientEventFactory
 from ducktape.tests.loader import TestLoader
 from ducktape.tests.serde import SerDe
-from ducktape.tests.status import FLAKY
+from ducktape.tests.status import FLAKY, TestStatus
 from ducktape.tests.test import test_logger, TestContext
 
 from ducktape.tests.result import TestResult, IGNORE, PASS, FAIL

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -120,7 +120,6 @@ class RunnerClient(object):
         data = None
         self.all_services = ServiceRegistry()
 
-        # mapping of summaries to the failing iteration
         summaries = []
         num_runs = 0
 

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -129,11 +129,10 @@ class RunnerClient(object):
                 self.log(logging.INFO, "on run {}/{}".format(num_runs, self.deflake_num))
                 start_time = time.time()
                 test_status, run_summary, data = self._do_run(num_runs)
-                # if deflake is enabled, and there is a summary to display, add a run msg
                 if run_summary:
                     summaries.append(run_summary)
-                # if run passed, and not on the first run, mention that it is now passing
 
+                # if run passed, and not on the first run, the test is flaky
                 if test_status == PASS and num_runs > 1:
                     test_status = FLAKY
 

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -525,7 +525,7 @@ class RemoteAccountTest(Test):
             assert self.wrote_log_line
 
         logging_thread.join(5.0)
-        if logging_thread.isAlive():
+        if logging_thread.is_alive():
             raise Exception("Timed out waiting for background thread.")
 
     @cluster(num_nodes=1)

--- a/systests/cluster/test_remote_account.py
+++ b/systests/cluster/test_remote_account.py
@@ -443,7 +443,17 @@ class RemoteAccountTest(Test):
 
     @cluster(num_nodes=1)
     def test_flaky(self):
-        assert random.choice([True, False, False])
+        choices = [
+            Exception("FLAKE 1"),
+            Exception("FLAKE 1"),
+            Exception("FLAKE 2"),
+            Exception("FLAKE 2"),
+            Exception("FLAKE 3"),
+            None,
+        ]
+        exp = random.choice(choices)
+        if exp:
+            raise exp
 
     @cluster(num_nodes=1)
     def test_ssh_capture_combine_stderr(self):


### PR DESCRIPTION
Motivation:
when getting a flaky test, the summaries are clear due to the last run passing, loosing all data of failed runs.  This PR intends to remedy this by changing the summary behavior of deflake runs.  In a deflake run, all summaries are included, and demarked by the run number and a ~~~~~:

<img width="1329" alt="image" src="https://user-images.githubusercontent.com/11418644/186264493-4762128c-a10e-48e1-8219-3329acba999a.png">


Testing:
ran unit tests and ran all system tests

