### PR TITLE
Runner Client Minor Refactor and Test

### DIFF
--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Counter, defaultdict
+from collections import defaultdict
 import logging
 import os
 import signal

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -52,7 +52,13 @@ class Sender(object):
     socket: zmq.Socket
     poller: zmq.Poller
 
-    def __init__(self, server_host: str, server_port: int, message_supplier: ClientEventFactory, logger: logging.Logger):
+    def __init__(
+        self,
+        server_host: str,
+        server_port: int,
+        message_supplier: ClientEventFactory,
+        logger: logging.Logger
+    ):
         self.serde = SerDe()
         self.server_endpoint = "tcp://%s:%s" % (str(server_host), str(server_port))
         self.zmq_context = zmq.Context()

--- a/ducktape/tests/runner_client.py
+++ b/ducktape/tests/runner_client.py
@@ -52,7 +52,6 @@ class Sender(object):
     socket: zmq.Socket
     poller: zmq.Poller
 
-
     def __init__(self, server_host: str, server_port: int, message_supplier: ClientEventFactory, logger: logging.Logger):
         self.serde = SerDe()
         self.server_endpoint = "tcp://%s:%s" % (str(server_host), str(server_port))
@@ -114,7 +113,6 @@ class RunnerClient(object):
     runner_port: int
     message: ClientEventFactory
     sender: Sender
-
 
     test_id: str
     test_index: int

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -118,6 +118,7 @@ class MockAccount(LinuxRemoteAccount):
 
 class MockSender(MagicMock):
     send_results: List[Tuple]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.send_results = []

--- a/tests/ducktape_mock.py
+++ b/tests/ducktape_mock.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Tuple
 from ducktape.cluster.cluster import Cluster
 from ducktape.cluster.cluster_spec import ClusterSpec, LINUX
 from ducktape.cluster.node_container import NodeContainer
 from ducktape.tests.session import SessionContext
-from ducktape.tests.test import TestContext
+from ducktape.tests.test import Test, TestContext
 from ducktape.cluster.linux_remoteaccount import LinuxRemoteAccount
 from ducktape.cluster.remoteaccount import RemoteAccountSSHConfig
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 import os
@@ -27,7 +28,11 @@ import tempfile
 
 
 def mock_cluster():
-    return MagicMock()
+    return MagicMock(
+        all=lambda: [MagicMock(spec=ClusterSpec)] * 3,
+        max_used=lambda: 3,
+        max_used_nodes=3
+    )
 
 
 class FakeClusterNode(object):
@@ -74,9 +79,21 @@ def session_context(**kwargs):
     return SessionContext(session_id="test_session", **kwargs)
 
 
+class TestMockTest(Test):
+    def mock_test(self):
+        pass
+
+
 def test_context(session_context=session_context(), cluster=mock_cluster()):
     """Return a TestContext object"""
-    return TestContext(session_context=session_context, file="a/b/c", cluster=cluster)
+    return TestContext(
+        session_context=session_context,
+        file="tests/ducktape_mock.py",
+        module=__name__,
+        cls=TestMockTest,
+        function=TestMockTest.mock_test,
+        cluster=cluster
+    )
 
 
 class MockNode(object):
@@ -97,3 +114,15 @@ class MockAccount(LinuxRemoteAccount):
             port=22)
 
         super(MockAccount, self).__init__(ssh_config, externally_routable_ip="localhost", logger=None, **kwargs)
+
+
+class MockSender(MagicMock):
+    send_results: List[Tuple]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.send_results = []
+
+    def send(self, *args, **kwargs):
+        self.send_results.append((
+            args, kwargs
+        ))

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -15,7 +15,6 @@
 from unittest.mock import patch
 
 import pytest
-from ducktape.cluster.cluster import Cluster
 
 from ducktape.cluster.node_container import NodeContainer, InsufficientResourcesError
 from ducktape.tests.runner_client import RunnerClient


### PR DESCRIPTION
The biggest change here to operations is organizational, the runner still calls `run_client` which does the same thing as before, but now `ready` has been extracted from the constructor, this way the constructor doesn't make any network calls.

Also for modern python development typing is now being used, and we have a specific runner client unit test.

Also for this tests mocks have been improved.

For typing reasons, Sender has been moved to the top of the file.