### PR TITLE
print ssh command output on debug level

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -396,7 +396,7 @@ class RemoteAccount(HttpMixin):
             stdin.close()
             stdout.close()
             stderr.close()
-
+        self._log(logging.DEBUG, "Returning ssh command output:\n%s" % stdoutdata)
         return stdoutdata
 
     def alive(self, pid):


### PR DESCRIPTION
We have a lot of tests that go like:
```python
assert "whatever" in node.account.ssh_output(...)
```
which makes it harder to debug what happened if it failed. With this change, we'll always have both the command and it's output printed on the debug level.
