### PR TITLE
handle edge case when wait is called on BackgroundThread that has never been started

### DIFF
--- a/ducktape/services/background_thread.py
+++ b/ducktape/services/background_thread.py
@@ -87,9 +87,14 @@ class BackgroundThreadService(Service):
 
     def wait_node(self, node, timeout_sec=600):
         idx = self.idx(node)
-        worker_thread = self.worker_threads[idx]
-        worker_thread.join(timeout_sec)
-        return not(worker_thread.is_alive())
+        worker_thread = self.worker_threads.get(idx)
+        # worker thread can be absent if this node has never been started
+        if worker_thread:
+            worker_thread.join(timeout_sec)
+            return not (worker_thread.is_alive())
+        else:
+            self.logger.debug(f"Worker thread not found for {self.who_am_i(node)}")
+            return True
 
     def _propagate_exceptions(self):
         """

--- a/ducktape/services/service_registry.py
+++ b/ducktape/services/service_registry.py
@@ -78,7 +78,7 @@ class ServiceRegistry(object):
             except BaseException as e:
                 if isinstance(e, KeyboardInterrupt):
                     keyboard_interrupt = e
-                service.logger.warn("Error cleaning service %s: %s" % (service, e))
+                service.logger.warn("Error freeing service %s: %s" % (service, e))
 
         if keyboard_interrupt is not None:
             raise keyboard_interrupt

--- a/tests/services/check_background_thread_service.py
+++ b/tests/services/check_background_thread_service.py
@@ -107,6 +107,11 @@ class CheckBackgroundThreadService(object):
         self.service.stop_node(node)
         assert self.service.wait_node(node)
 
+    def check_wait_node_no_start(self):
+        self.service = DummyService(self.context, run_time_sec=float('inf'))
+        node = self.service.nodes[0]
+        assert self.service.wait_node(node)
+
     def check_background_exception(self):
         self.service = DummyService(self.context, float('inf'), Exception('failure'))
         self.service.start()


### PR DESCRIPTION
If BackgroundThread object has never been started, calling `wait()` on it will crash since worker_threads won't contain a thread for this worker. This PR adds a safety check around that case.

We discovered it the hard way, with confluent kafka system tests. Debugging this issue was not straightforward for some reason, since the exception is silenced by ducktape (this is another problem not tackled by this PR).


This PR also adds a couple of useful debug lines which we added when debugging an issue with confluent system tests.