### PR TITLE
Adding nodes used in test summary for HTML report

### DIFF
--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -222,10 +222,10 @@ class JUnitReporter(object):
 class HTMLSummaryReporter(SummaryReporter):
 
     def format_test_name(self, result):
-        lines = ["Module: " + result.module_name,
-                 "Class:  " + result.cls_name,
-                 "Method: " + result.function_name,
-                 "Nodes:  " + str(result.nodes_used)]
+        lines = ["Module:      " + result.module_name,
+                 "Class:       " + result.cls_name,
+                 "Method:      " + result.function_name,
+                 f"Nodes (used/allocated): {result.nodes_used}/{result.nodes_allocated}"]
 
         if result.injected_args is not None:
             lines.append("Arguments:")

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -224,7 +224,8 @@ class HTMLSummaryReporter(SummaryReporter):
     def format_test_name(self, result):
         lines = ["Module: " + result.module_name,
                  "Class:  " + result.cls_name,
-                 "Method: " + result.function_name]
+                 "Method: " + result.function_name,
+                 "Nodes:  " + str(result.nodes_used)]
 
         if result.injected_args is not None:
             lines.append("Arguments:")


### PR DESCRIPTION
This adds the number of nodes used by the test in the HTML report.
<img width="792" alt="Screenshot 2023-02-07 at 10 35 56 PM" src="https://user-images.githubusercontent.com/77335886/217315483-678bf453-f6bf-4245-a1d6-7a4e8c55ad0e.png">
