### PR TITLE
lock pyspnego dependency to py2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ cryptography==3.3.2
 certifi==2020.04.05.1
 # xmltodict is required for pywinrm, but as they didn't pin their python2 version, we have to
 xmltodict==0.12.0
+pyspnego<0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ certifi==2020.04.05.1
 # xmltodict is required for pywinrm, but as they didn't pin their python2 version, we have to
 xmltodict==0.12.0
 pyspnego<0.2.0
+requests-ntlm==1.1.0


### PR DESCRIPTION
Because otherwise it pulls python3 version automatically.
This fix is for ducktape 0.7.x only and will not be propagated to later branches.