### PR TITLE
added manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include requirements-test.txt


### PR DESCRIPTION
this should fix the following issue that somehow only happens on 0.7.x.
```
Searching for ducktape<0.8,>0.7
Reading https://pypi.org/simple/ducktape/
Downloading https://files.pythonhosted.org/packages/dd/d3/699fe87d2694e41ee56283b86083ad12fa2edf697495d328a8f6da557783/ducktape-0.7.22.tar.gz#sha256=c6af8ee2b3c45a5474ff166c2affc1e808be7cf4d609a1145180eeb64643d453
Best match: ducktape 0.7.22
Processing ducktape-0.7.22.tar.gz
Writing /var/folders/vk/9xmgp9w16dj3ty41013x0zt80000gn/T/easy_install-jv2aym/ducktape-0.7.22/setup.cfg
Running ducktape-0.7.22/setup.py -q bdist_egg --dist-dir /var/folders/vk/9xmgp9w16dj3ty41013x0zt80000gn/T/easy_install-jv2aym/ducktape-0.7.22/egg-dist-tmp-nw9iyZ
error: [Errno 2] No such file or directory: 'requirements-test.txt'
```