### PR TITLE
DPTFI-471 Update CODEOWNERS replace quality-eng & test-frameworks with testframeworks-and-insights

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Make Confluent Quality team the default reviewers (but not required reviewers) on all PRs.
-* @confluentinc/test-frameworks
+* @confluentinc/testframeworks-and-insights


### PR DESCRIPTION
# Change Description
As a part of recent restructuring, the QE team has moved to DevProd Test
Frameworks and Insights. The purpose of this changeset is to transfer code
ownership from the `quality-eng` GitHub team and its 'test-frameworks'
sub-team to the `testframeworks-and-insights` team.

# Changes
Replace `@confluentinc/quality-eng` and `@confluentinc/test-frameworks` with
`@confluentinc/testframeworks-and-insights` in the CODEOWNERS file.
Which may be located either at `<repository-root>/.github/CODEOWNERS` or
`<repository-root>/CODEOWNERS`.
