### PR TITLE
reverting the requests version update in 0.8.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ MarkupSafe<2.0.0
 pyparsing<3.0.0
 zipp<2.0.0
 pywinrm==0.2.2
-requests==2.31.0
+requests==2.24.0
 paramiko~=2.7.2
 pyzmq==19.0.2
 pycryptodome==3.9.8


### PR DESCRIPTION
Reverting this as per https://confluent.slack.com/archives/C02T3U9S6BF/p1693467278490059?thread_ts=1692903126.852429&cid=C02T3U9S6BF. This is being reverted since it is blocking the release process and currently kafka validation is causing some issues as mentioned in the attached thread. 

We will make these changes again once kafka team validates the changes. (https://confluentinc.atlassian.net/browse/CPTF-108)