### PR TITLE
Add yaml files for onboarding ducktape to semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,25 @@
+version: v1.0
+name: pr-test-job
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+execution_time_limit:
+  hours: 1
+
+global_job_config:
+  prologue:
+    commands:
+      - . vault-setup
+      - sem-version python 3.9
+      - pip install tox
+      - checkout
+blocks:
+  - name: Test
+    dependencies: []
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - export PYTESTARGS='--junitxml=test/results.xml'
+            - tox

--- a/service.yml
+++ b/service.yml
@@ -5,3 +5,15 @@ git:
   enable: true
 sonarqube:
   enable: false
+github:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_enable: false
+  branches:
+    - master
+    - 0.11.x
+    - 0.10.x
+    - 0.9.x
+    - 0.8.x
+    - 0.7.x


### PR DESCRIPTION
# What ?
Added necessary yamls files for onboarding ducktape to semaphore

# Why?
Ducktape repo needs to be onboarded to Confluent Semaphore public as confluent public jenkins is deprecated already. Forked PRs can't be tested using PR job without this onboarding.