### PR TITLE
Add the missing psutil dependency

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,6 @@
 pytest~=6.2.0
 # 4.0 drops py27 support
 mock==4.0.2
-psutil==5.7.2
 memory_profiler==0.57
 statistics==1.0.3.5
 requests-testadapter==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyzmq==25.1.2
 pycryptodome==3.9.8
 more-itertools==5.0.0
 PyYAML==5.3.1
+psutil==5.7.2


### PR DESCRIPTION
Now the psutil module used not only in the unit tests.

So move it to requirements.txt

Fixes the https://github.com/confluentinc/ducktape/issues/419