### PR TITLE
Upgrade PyYAML and fix style error

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -318,7 +318,6 @@ class TestRunner(object):
         self.client_report[test_key]["name"] = proc.name
         self.client_report[test_key]["runner_start_time"] = time.time()
 
-
     def _preallocate_subcluster(self, test_context):
         """Preallocate the subcluster which will be used to run the test.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ paramiko~=2.10.0
 pyzmq==25.1.2
 pycryptodome==3.19.1
 more-itertools==5.0.0
-PyYAML==5.4
+PyYAML==6.0.2
 psutil==5.7.2


### PR DESCRIPTION
### Description

This code change:

- Fixes the PyYAML dependency and upgrades to 6.0.2
- Fixes style issue in `runner.py`

### Issue
PyYAML install was failing.
```
Collecting PyYAML==5.4
  Using cached https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/pypi/pypi/simple/pyyaml/5.4/PyYAML-5.4.tar.gz (174 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error

  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [48 lines of output]
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/Users/saurabhyadav/Documents/workplace/workspaces/ducktape/.virtualenvs/ducktape-py38/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/Users/saurabhyadav/Documents/workplace/workspaces/ducktape/.virtualenvs/ducktape-py38/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
        File "/Users/saurabhyadav/Documents/workplace/workspaces/ducktape/.virtualenvs/ducktape-py38/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 303, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 319, in run_setup
          exec(code, locals())
        File "<string>", line 271, in <module>
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 183, in setup
          return run_commands(dist)
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 199, in run_commands
          dist.run_commands()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 954, in run_commands
          self.run_command(cmd)
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 312, in run
          self.find_sources()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 320, in find_sources
          mm.run()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 541, in run
          self.add_defaults()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 579, in add_defaults
          sdist.add_defaults(self)
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/command/sdist.py", line 109, in add_defaults
          super().add_defaults()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 238, in add_defaults
          self._add_defaults_ext()
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 323, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 201, in get_source_files
        File "/private/var/folders/mz/phbpclf10bxc2tcc4wl85xy00000gp/T/pip-build-env-s5zjpxqg/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
```
