### PR TITLE
ADD python 3.13 support and run pr-test-job with py313

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,7 +10,7 @@ execution_time_limit:
 global_job_config:
   prologue:
     commands:
-      - sem-version python 3.9
+      - sem-version python 3.13
       - pip install tox
       - checkout
 blocks:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,15 +10,47 @@ execution_time_limit:
 global_job_config:
   prologue:
     commands:
-      - sem-version python 3.13
-      - pip install tox
       - checkout
+
+
 blocks:
   - name: Test
     dependencies: []
     task:
       jobs:
-        - name: Test
+        - name: Test Python 3.8
           commands:
-            - export PYTESTARGS='--junitxml=test/results.xml'
-            - tox
+            - sem-version python 3.8
+            - pip install tox
+            - export PYTESTARGS='--junitxml=test/results-py38.xml'
+            - tox -e py38
+        - name: Test Python 3.9
+          commands:
+            - sem-version python 3.9
+            - pip install tox
+            - export PYTESTARGS='--junitxml=test/results-py39.xml'
+            - tox -e py39
+        - name: Test Python 3.10
+          commands:
+            - sem-version python 3.10
+            - pip install tox
+            - export PYTESTARGS='--junitxml=test/results-py310.xml'
+            - tox -e py310
+        - name: Test Python 3.11
+          commands:
+            - sem-version python 3.11
+            - pip install tox
+            - export PYTESTARGS='--junitxml=test/results-py311.xml'
+            - tox -e py311
+        - name: Test Python 3.12
+          commands:
+            - sem-version python 3.12
+            - pip install tox
+            - export PYTESTARGS='--junitxml=test/results-py312.xml'
+            - tox -e py312
+        - name: Test Python 3.13
+          commands:
+            - sem-version python 3.13
+            - pip install tox
+            - export PYTESTARGS='--junitxml=test/results-py313.xml'
+            - tox -e py313

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -53,4 +53,4 @@ blocks:
             - sem-version python 3.13
             - pip install tox
             - export PYTESTARGS='--junitxml=test/results-py313.xml'
-            - tox -e py313
+            - tox

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
-Sphinx<1.7
-sphinx-argparse==0.1.17
-sphinx-rtd-theme==0.2.4
-boto3==1.15.9
-pycryptodome==3.19.1
-pywinrm==0.2.2
-jinja2~=3.0.3
-MarkupSafe~=2.0.0
+Sphinx~=8.2.3
+sphinx-argparse~=0.5.2
+sphinx-rtd-theme~=3.0.2
+boto3==1.33.13
+pycryptodome==3.23.0
+pywinrm==0.4.3
+jinja2~=3.1.6
+MarkupSafe~=2.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-jinja2~=3.0.3
-boto3==1.20.54
+jinja2~=3.1.6
+boto3==1.33.13
 # jinja2 pulls in MarkupSafe with a > constraint, but we need to constrain it for compatibility
-MarkupSafe~=2.0.0
-pyparsing<3.0.0
-zipp<2.0.0
+MarkupSafe~=2.1.5
+pyparsing==3.1.4
+zipp==3.20.2
 pywinrm==0.4.3
 requests==2.32.2
-paramiko~=2.10.0
-pyzmq==25.1.2
-pycryptodome==3.19.1
+paramiko~=2.12.0
+pyzmq==26.4.0
+pycryptodome==3.23.0
 more-itertools==5.0.0
 PyYAML==6.0.2
 psutil==5.7.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, cover, style, docs
+envlist = py38, py39, py310, py311, py312, py313, cover, style, docs
 
 [testenv]
 # Consolidate all deps here instead of separately in test/style/cover so we
@@ -35,21 +35,24 @@ envdir = {package_root}/.virtualenvs/ducktape-py311
 [testenv:py312]
 envdir = {package_root}/.virtualenvs/ducktape-py312
 
+[testenv:py313]
+envdir = {package_root}/.virtualenvs/ducktape-py313
+
 [testenv:style]
-basepython = python3.12
+basepython = python3.13
 envdir = {package_root}/.virtualenvs/ducktape
 commands =
     flake8 --config tox.ini
 
 [testenv:cover]
-basepython = python3.12
+basepython = python3.13
 envdir = {package_root}/.virtualenvs/ducktape
 commands =
     pytest {env:PYTESTARGS:} --cov ducktape --cov-report=xml --cov-report=html --cov-report=term --cov-report=annotate:textcov \
                              --cov-fail-under=70
 
 [testenv:docs]
-basepython = python3.8
+basepython = python3.13
 deps =
     -r {toxinidir}/docs/requirements.txt
 changedir = {toxinidir}/docs


### PR DESCRIPTION
### Description
This code change 

- Adds python 3.13 support to ducktape
- Upgrades dependencies to newer version
- Changes semaphore PR Test Job to run with python 3.13

### Testing
Ran the kraft_remote_suite: https://semaphore.ci.confluent.io/jobs/62b874eb-bd25-433e-baad-42795d7132de 
10 tests failed but are unrelated to this upgrade as they are also failing with 8.0.x branch. Ref: https://confluent.slack.com/archives/C0F7NKDGD/p1745590674571609