### PR TITLE
CPTF-1049 | report.html: Report expected test count in the summary

### DIFF
--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -216,7 +216,8 @@ def main():
     update_latest_symlink(args_dict["results_root"], results_dir)
 
     if len(test_results) < expected_test_count:
-        session_logger.warning(f"All tests were NOT run. Expected {expected_test_count} tests, only {len(test_results)} were run.")
+        session_logger.warning(
+            f"All tests were NOT run. Expected {expected_test_count} tests, only {len(test_results)} were run.")
         close_logger(session_logger)
         sys.exit(1)
 
@@ -224,4 +225,3 @@ def main():
     if not test_results.get_aggregate_success():
         # Non-zero exit if at least one test failed
         sys.exit(1)
-

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -145,7 +145,7 @@ def main():
         sys.exit(1)
 
     expected_test_count = len(tests)
-    print(f"Discovered {expected_test_count} tests to run")
+    session_logger.info(f"Discovered {expected_test_count} tests to run")
 
     if args_dict["collect_only"]:
         print("Collected %d tests:" % expected_test_count)
@@ -200,6 +200,8 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
+    expected_test_count += 1  # TODO: this is for testing purposes, remove later
+
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),
@@ -214,6 +216,12 @@ def main():
         r.report()
 
     update_latest_symlink(args_dict["results_root"], results_dir)
+
+    if len(test_results) < expected_test_count:
+        session_logger.warning(f"All tests were NOT run. Expected {expected_test_count} tests, only {len(test_results)} were run.")
+        close_logger(session_logger)
+        sys.exit(1)
+
     close_logger(session_logger)
     if not test_results.get_aggregate_success():
         # Non-zero exit if at least one test failed

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import importlib
 import json
+import logging
 import os
 import random
 import sys
@@ -198,6 +199,7 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
+    logging.info(f"expected test count: {expected_test_count}")
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -140,14 +140,15 @@ def main():
     )
 
     expected_test_count = 0
+    tests = []
     try:
         tests = loader.load(args_dict["test_path"], excluded_test_symbols=args_dict['exclude'])
-        expected_test_count = len(tests)
-        print(f"Discovered {expected_test_count} tests to run")
     except LoaderException as e:
         print("Failed while trying to discover tests: {}".format(e))
         sys.exit(1)
 
+    expected_test_count = len(tests)
+    print(f"Discovered {expected_test_count} tests to run")
     if args_dict["collect_only"]:
         print("Collected %d tests:" % expected_test_count)
         for test in tests:
@@ -201,12 +202,13 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
-    print(f"expected test count: {expected_test_count}")
+    print("expected test count: ")
+    print(expected_test_count)
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),
         SimpleFileSummaryReporter(test_results),
-        HTMLSummaryReporter(test_results, expected_test_count),
+        HTMLSummaryReporter(results=test_results, expected_test_count=expected_test_count),
         JSONReporter(test_results),
         JUnitReporter(test_results),
         FailedTestSymbolReporter(test_results)
@@ -220,3 +222,4 @@ def main():
     if not test_results.get_aggregate_success():
         # Non-zero exit if at least one test failed
         sys.exit(1)
+

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -138,9 +138,12 @@ def main():
         subsets=args_dict["subsets"],
         historical_report=args_dict["historical_report"],
     )
+
+    expected_test_count = 0
     try:
         tests = loader.load(args_dict["test_path"], excluded_test_symbols=args_dict['exclude'])
         expected_test_count = len(tests)
+        print(f"Discovered {expected_test_count} tests to run")
     except LoaderException as e:
         print("Failed while trying to discover tests: {}".format(e))
         sys.exit(1)

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -140,12 +140,13 @@ def main():
     )
     try:
         tests = loader.load(args_dict["test_path"], excluded_test_symbols=args_dict['exclude'])
+        expected_test_count = len(tests)
     except LoaderException as e:
         print("Failed while trying to discover tests: {}".format(e))
         sys.exit(1)
 
     if args_dict["collect_only"]:
-        print("Collected %d tests:" % len(tests))
+        print("Collected %d tests:" % expected_test_count)
         for test in tests:
             print("    " + str(test))
         sys.exit(0)
@@ -201,7 +202,7 @@ def main():
     reporters = [
         SimpleStdoutSummaryReporter(test_results),
         SimpleFileSummaryReporter(test_results),
-        HTMLSummaryReporter(test_results),
+        HTMLSummaryReporter(test_results, expected_test_count),
         JSONReporter(test_results),
         JUnitReporter(test_results),
         FailedTestSymbolReporter(test_results)

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 
 import importlib
 import json
-import logging
 import os
 import random
 import sys
@@ -199,7 +198,7 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
-    logging.info(f"expected test count: {expected_test_count}")
+    print(f"expected test count: {expected_test_count}")
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -202,13 +202,14 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
+    expected_test_count = len(loader.load(args_dict["test_path"], excluded_test_symbols=args_dict['exclude']))
     print("expected test count: ")
     print(expected_test_count)
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),
         SimpleFileSummaryReporter(test_results),
-        HTMLSummaryReporter(results=test_results, expected_test_count=expected_test_count),
+        HTMLSummaryReporter(test_results, expected_test_count),
         JSONReporter(test_results),
         JUnitReporter(test_results),
         FailedTestSymbolReporter(test_results)

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -138,9 +138,6 @@ def main():
         subsets=args_dict["subsets"],
         historical_report=args_dict["historical_report"],
     )
-
-    expected_test_count = 0
-    tests = []
     try:
         tests = loader.load(args_dict["test_path"], excluded_test_symbols=args_dict['exclude'])
     except LoaderException as e:
@@ -149,6 +146,7 @@ def main():
 
     expected_test_count = len(tests)
     print(f"Discovered {expected_test_count} tests to run")
+
     if args_dict["collect_only"]:
         print("Collected %d tests:" % expected_test_count)
         for test in tests:
@@ -202,9 +200,6 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
-    expected_test_count = len(loader.load(args_dict["test_path"], excluded_test_symbols=args_dict['exclude']))
-    print("expected test count: ")
-    print(expected_test_count)
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),

--- a/ducktape/command_line/main.py
+++ b/ducktape/command_line/main.py
@@ -200,8 +200,6 @@ def main():
     runner = TestRunner(cluster, session_context, session_logger, tests, deflake_num)
     test_results = runner.run_all_tests()
 
-    expected_test_count += 1  # TODO: this is for testing purposes, remove later
-
     # Report results
     reporters = [
         SimpleStdoutSummaryReporter(test_results),

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -37,7 +37,8 @@
         render: function() {
           return (
             <tr>
-              <td colSpan='5' align='center'>{this.props.summary_prop.tests}</td>
+              <td colSpan='5' align='center'>{this.props.summary_prop.expected_test_count}</td>
+              <td colSpan='5' align='center'>{this.props.summary_prop.tests_run}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.passes}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.flaky}</td>
               <td colSpan='5' align='center'>{this.props.summary_prop.failures}</td>
@@ -179,8 +180,8 @@
       });
 
       SUMMARY=[{
-        "expected test count": %(expected_test_count)d,
-        "tests run": %(num_tests_run)d,
+        "expected_test_count": %(expected_test_count)d,
+        "tests_run": %(num_tests_run)d,
         "passes": %(num_passes)d,
         "flaky": %(num_flaky)d,
         "failures": %(num_failures)d,

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -54,7 +54,8 @@
             <table id="summary_report_table">
               <thead>
                 <tr id="summary_header_row">
-                  <th colSpan='5' align='center'>Tests</th>
+                  <th colSpan='5' align='center'>Expected Test Count</th>
+                  <th colSpan='5' align='center'>Tests Run</th>
                   <th colSpan='5' align='center'>Passes</th>
                   <th colSpan='5' align='center'>Flaky</th>
                   <th colSpan='5' align='center'>Failures</th>

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -178,7 +178,8 @@
       });
 
       SUMMARY=[{
-        "tests": %(num_tests)d,
+        "expected test count": %(expected_test_count)d,
+        "tests run": %(num_tests_run)d,
         "passes": %(num_passes)d,
         "flaky": %(num_flaky)d,
         "failures": %(num_failures)d,

--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -55,7 +55,7 @@
             <table id="summary_report_table">
               <thead>
                 <tr id="summary_header_row">
-                  <th colSpan='5' align='center'>Expected Test Count</th>
+                  <th colSpan='5' align='center'>Tests Expected</th>
                   <th colSpan='5' align='center'>Tests Run</th>
                   <th colSpan='5' align='center'>Passes</th>
                   <th colSpan='5' align='center'>Flaky</th>

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -218,6 +218,9 @@ class JUnitReporter(object):
 
 
 class HTMLSummaryReporter(SummaryReporter):
+    def __init__(self, results, expected_test_count):
+        super().__init__(results)
+        self.expected_test_count = expected_test_count
 
     def format_test_name(self, result):
         lines = ["Module:      " + result.module_name,
@@ -267,7 +270,7 @@ class HTMLSummaryReporter(SummaryReporter):
             import pkg_resources
             template = pkg_resources.resource_string(__name__, '../templates/report/report.html').decode('utf-8')
 
-        num_tests = len(self.results)
+        num_tests_run = len(self.results)
         num_passes = 0
         failed_result_string = []
         passed_result_string = []
@@ -294,7 +297,8 @@ class HTMLSummaryReporter(SummaryReporter):
 
         args = {
             'ducktape_version': ducktape_version(),
-            'num_tests': num_tests,
+            'expected_test_count': self.expected_test_count,
+            'num_tests_run': num_tests_run,
             'num_passes': self.results.num_passed,
             'num_flaky': self.results.num_flaky,
             'num_failures': self.results.num_failed,

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -116,6 +116,7 @@ class TestRunner(object):
 
         self.main_process_pid = os.getpid()
         self.scheduler = TestScheduler(tests, self.cluster)
+        self.expected_test_count = len(tests)
 
         self.test_counter = 1
         self.total_tests = len(self.scheduler)
@@ -387,7 +388,7 @@ class TestRunner(object):
         test_results = copy.copy(self.results)  # shallow copy
         reporters = [
             SimpleFileSummaryReporter(test_results),
-            HTMLSummaryReporter(test_results, self.total_tests),
+            HTMLSummaryReporter(test_results, self.expected_test_count),
             JSONReporter(test_results)
         ]
         for r in reporters:

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -387,7 +387,7 @@ class TestRunner(object):
         test_results = copy.copy(self.results)  # shallow copy
         reporters = [
             SimpleFileSummaryReporter(test_results),
-            HTMLSummaryReporter(test_results),
+            HTMLSummaryReporter(test_results, self.total_tests),
             JSONReporter(test_results)
         ]
         for r in reporters:

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -116,7 +116,6 @@ class TestRunner(object):
 
         self.main_process_pid = os.getpid()
         self.scheduler = TestScheduler(tests, self.cluster)
-        self.expected_test_count = len(tests)
 
         self.test_counter = 1
         self.total_tests = len(self.scheduler)
@@ -388,7 +387,7 @@ class TestRunner(object):
         test_results = copy.copy(self.results)  # shallow copy
         reporters = [
             SimpleFileSummaryReporter(test_results),
-            HTMLSummaryReporter(test_results, self.expected_test_count),
+            HTMLSummaryReporter(test_results, self.total_tests),
             JSONReporter(test_results)
         ]
         for r in reporters:


### PR DESCRIPTION
### Background
There have been cases where ducktape fails to report all the tests that were part of the list of tests to run. This is usually seen in parallel to the issue of `runner_client unresponsive`, and the corresponding test handled by that runner_client will not be part of any of the reports (report.txt, report.html etc). For example, this is a report of a run that initially collected 1232 tests, but only reported 975:
<img width="1541" alt="Screenshot 2025-06-09 at 00 08 28" src="https://github.com/user-attachments/assets/bd370830-5081-4f4a-941a-ac4d4c6bbd49" />

Hence this code change: When the above issue is hit, we want to flag a warning in the logs, ducktape should exit with return code 1, and explicitly mention this in report.html. Here's an edited version of the above snapshot of report.html:
<img width="1539" alt="Screenshot 2025-06-09 at 00 09 26" src="https://github.com/user-attachments/assets/c9fe3689-c4bf-487d-991f-9f075d85235f" />
<img width="1178" alt="Screenshot 2025-06-08 at 23 49 02" src="https://github.com/user-attachments/assets/8329899a-1cf8-41d7-b372-5ce95b732d0e" />

### Code changes
* main.py: Introduce a new variable: `expected_test_count`, which holds the total number of tests expected to run. Pass this while initiating an instance of `HTMLSummaryReporter`.
* reporter.py: Modify the `HTMLSummaryReporter` to accept this new variable to be displayed in the summary panel of report.html. Also update the `report.html` template.

Snapshot from an actual run:
<img width="1539" alt="Screenshot 2025-06-09 at 00 13 06" src="https://github.com/user-attachments/assets/2cec6dff-862d-40b4-8df7-859efd87822a" />
job: https://semaphore.ci.confluent.io/jobs/4e032d5e-56f4-4543-a0e9-a81f3b6dbcec (accessible only by Confluent engineers)

### Out of scope
Please note: This change only flags if any test is missing from the reports. Ducktape still WOULD NOT list out the tests that are missing.