### PR TITLE
Revert "ADD changelog in docs for v0.13.0 release (#437)"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,19 +4,6 @@
 Changelog
 ====
 
-0.13.0
-======
-Monday, June 9th, 2025
---------------------------
-- Report expected test count in the summary
-- Add python 3.13 support and run pr-test-job with all supported python versions
-- Upgrade PyYAML and fix style error
-- Add support for historical report in loader
-- Update dependency PyYAML to v5.4
-- Update dependency requests to v2.32.2
-- Update dependency pycryptodome to v3.19.1
-- Removing generated internal project.yml, public project.yml
-
 0.12.0
 ======
 Friday, October 04th, 2024


### PR DESCRIPTION
This reverts commit 5479e4eb81a57b8a837e581eb09b9d5cd628a543 as release job adds automated change log and this would conflict.