### PR TITLE
CPTF-1147 | Generate report.xml after each test

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -33,7 +33,7 @@ from ducktape.tests.event import ClientEventFactory, EventResponseFactory
 from ducktape.cluster.finite_subcluster import FiniteSubcluster
 from ducktape.tests.scheduler import TestScheduler
 from ducktape.tests.result import FAIL, TestResult
-from ducktape.tests.reporter import SimpleFileSummaryReporter, HTMLSummaryReporter, JSONReporter
+from ducktape.tests.reporter import SimpleFileSummaryReporter, HTMLSummaryReporter, JSONReporter, JUnitReporter
 from ducktape.utils import persistence
 from ducktape.errors import TimeoutError
 
@@ -388,7 +388,8 @@ class TestRunner(object):
         reporters = [
             SimpleFileSummaryReporter(test_results),
             HTMLSummaryReporter(test_results, self.total_tests),
-            JSONReporter(test_results)
+            JSONReporter(test_results),
+            JUnitReporter(test_results)
         ]
         for r in reporters:
             r.report()


### PR DESCRIPTION
### Description
* system tests depend on report.xml to render test reports on Semaphore CI's UI.
* In case ducktape hits `runner-client unresponsive` error, it terminated immediately, leaving behind only those reports that were last generated when some other test completed. Now adding `report.xml` to also be generated after each test like `report.json & report.txt`. 

### Testing
Tested ducktape on branch `generate-xml` with a few system tests in which one was setup to fail with `runner client unresponsive`.
job link: https://semaphore.ci.confluent.io/workflows/b2528249-de06-40c4-8ad7-8a456fe71556 (accessible only for Confluent engineers)
