### PR TITLE
Fixe python version in readthedocs.yml and change log for v0.13.0 so that with the new release it gets fixed

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.13"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,12 +9,9 @@ Changelog
 Monday, June 09th, 2025
 -----------------------
 - Report expected test count in the summary
-- Add python 3.13 support and run pr
-- test
-- job with all supported python versions
+- Add python 3.13 support and run pr test job with all supported python versions
 - Upgrade PyYAML and fix style error
 - Add support for historical report in loader
-- Update dependency PyYAML to v5.4
 - Update dependency requests to v2.32.2
 - Update dependency pycryptodome to v3.19.1
 - Removing generated internal project.yml, public project.yml


### PR DESCRIPTION
### Description
This commit 
1. Fixes change log for `v0.13.0` so that with the new release it gets fixed
2. Upgrades the python version to 3.13 for `readthedocs.yml`. Without this the `buildthedocs` build fails: https://app.readthedocs.org/projects/ducktape/builds/28521671/