### PR TITLE
Disable renovatebot auto-merge

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -8,6 +8,10 @@ sonarqube:
 github:
   enable: true
   repo_name: confluentinc/ducktape
+renovatebot:
+  enable: true
+  automerge:
+    enable: false
 semaphore:
   enable: true
   pipeline_enable: false


### PR DESCRIPTION
### Description
This change adds renovate bot config to disable auto merge. This is expected to prevent any dependency upgrades being merged to master by the service bot even before review.