### PR TITLE
Ensure log collection in case of runner client unresponsive issue

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -47,7 +47,7 @@ from ducktape.tests.session import SessionContext
 from ducktape.tests.test_context import TestContext
 from ducktape.utils.terminal_size import get_terminal_size
 
-DEFAULT_MP_JOIN_TIMEOUT = 30
+DEFAULT_MP_JOIN_TIMEOUT = 120
 
 
 class Receiver(object):

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -150,9 +150,14 @@ class TestRunner(object):
 
     def _terminate_process(self, process: multiprocessing.Process):
         # use os.kill rather than multiprocessing.terminate for more control
+        # This is called after SIGTERM was sent and process didn't exit, so escalate to SIGKILL
         assert process.pid != os.getpid(), "Signal handler should not reach this point in a client subprocess."
         assert process.pid is not None, "Process has no pid, cannot terminate."
         if process.is_alive():
+            self._log(
+                logging.WARNING,
+                f"Process {process.name} did not respond to SIGTERM, escalating to SIGKILL"
+            )
             os.kill(process.pid, signal.SIGKILL)
 
     def _join_test_process(self, process_key, timeout: int = DEFAULT_MP_JOIN_TIMEOUT):
@@ -365,7 +370,18 @@ class TestRunner(object):
                         err_str += "\n" + traceback.format_exc(limit=16)
                         self._log(logging.ERROR, err_str)
 
-                        # Clean up stuck client processes and stop testing
+                        # Send SIGTERM to all client processes immediately to allow graceful cleanup
+                        # (copy logs, run teardown, etc.)
+                        for process_key in list(self._client_procs.keys()):
+                            proc = self._client_procs[process_key]
+                            if proc.is_alive():
+                                self._log(
+                                    logging.INFO,
+                                    f"Sending SIGTERM to process {proc.name} for graceful shutdown"
+                                )
+                                os.kill(proc.pid, signal.SIGTERM)
+
+                        # Wait for processes to shutdown gracefully, escalate to SIGKILL if needed
                         for proc in list(self._client_procs):
                             self._join_test_process(proc, self.finish_join_timeout)
                         self._client_procs = {}

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -154,10 +154,7 @@ class TestRunner(object):
         assert process.pid != os.getpid(), "Signal handler should not reach this point in a client subprocess."
         assert process.pid is not None, "Process has no pid, cannot terminate."
         if process.is_alive():
-            self._log(
-                logging.WARNING,
-                f"Process {process.name} did not respond to SIGTERM, escalating to SIGKILL"
-            )
+            self._log(logging.WARNING, f"Process {process.name} did not respond to SIGTERM, escalating to SIGKILL")
             os.kill(process.pid, signal.SIGKILL)
 
     def _join_test_process(self, process_key, timeout: int = DEFAULT_MP_JOIN_TIMEOUT):
@@ -375,10 +372,7 @@ class TestRunner(object):
                         for process_key in list(self._client_procs.keys()):
                             proc = self._client_procs[process_key]
                             if proc.is_alive():
-                                self._log(
-                                    logging.INFO,
-                                    f"Sending SIGTERM to process {proc.name} for graceful shutdown"
-                                )
+                                self._log(logging.INFO, f"Sending SIGTERM to process {proc.name} for graceful shutdown")
                                 os.kill(proc.pid, signal.SIGTERM)
 
                         # Wait for processes to shutdown gracefully, escalate to SIGKILL if needed

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -369,12 +369,15 @@ class TestRunner(object):
 
                         # Send SIGTERM to all client processes immediately to allow graceful cleanup
                         # (copy logs, run teardown, etc.)
-                        for proc in list(self._client_procs):
+                        for process_key in list(self._client_procs.keys()):
+                            proc = self._client_procs[process_key]
                             if proc.is_alive():
                                 self._log(logging.INFO, f"Sending SIGTERM to process {proc.name} for graceful shutdown")
                                 os.kill(proc.pid, signal.SIGTERM)
-                            # Wait for processes to shutdown gracefully, escalate to SIGKILL if needed
-                            self._join_test_process(proc, self.finish_join_timeout)
+
+                        # Wait for processes to shutdown gracefully (in parallel), escalate to SIGKILL if needed
+                        for process_key in list(self._client_procs.keys()):
+                            self._join_test_process(process_key, self.finish_join_timeout)
                         self._client_procs = {}
                         # Mark active tests as failed with the exception message
                         self._report_active_as_failed(str(e))

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -369,17 +369,13 @@ class TestRunner(object):
 
                         # Send SIGTERM to all client processes immediately to allow graceful cleanup
                         # (copy logs, run teardown, etc.)
-                        for process_key in list(self._client_procs.keys()):
-                            proc = self._client_procs[process_key]
+                        for proc in list(self._client_procs):
                             if proc.is_alive():
                                 self._log(logging.INFO, f"Sending SIGTERM to process {proc.name} for graceful shutdown")
                                 os.kill(proc.pid, signal.SIGTERM)
-
-                        # Wait for processes to shutdown gracefully, escalate to SIGKILL if needed
-                        for proc in list(self._client_procs):
+                            # Wait for processes to shutdown gracefully, escalate to SIGKILL if needed
                             self._join_test_process(proc, self.finish_join_timeout)
                         self._client_procs = {}
-
                         # Mark active tests as failed with the exception message
                         self._report_active_as_failed(str(e))
 


### PR DESCRIPTION
### Description
This PR:
1. First sends a SIGTERM signal to allow runner client to exit gracefully and then collect logs. If process is still active, send SIGKILL as is the current beahviour.
2. Increases the DEFAULT_MP_JOIN_TIMEOUT to ensure 1 can be done.

### Testing
Semaphore job: https://semaphore.ci.confluent.io/jobs/64a44b9a-ef0f-4545-bc45-0ff67e46bdbe
The report has all the logs for each service that was initiated

<img width="1885" height="636" alt="image" src="https://github.com/user-attachments/assets/33c7a9d7-05af-4e8c-90c6-e56ed59338f0" />
