### PR TITLE
Add node_type information to JSON Report

### DIFF
--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -50,6 +50,10 @@ class TestResult(object):
         """
         self.nodes_allocated = len(test_context.cluster)
         self.nodes_used = test_context.cluster.max_used_nodes
+
+        # Collect node_type from cluster metadata if available
+        self.node_type = test_context.cluster_use_metadata.get("node_type")
+
         if hasattr(test_context, "services"):
             self.services = test_context.services.to_json()
         else:
@@ -113,7 +117,7 @@ class TestResult(object):
             json.dump(self, fd, cls=DucktapeJSONEncoder, sort_keys=True, indent=2)
 
     def to_json(self):
-        return {
+        result = {
             "test_id": self.test_id,
             "module_name": self.module_name,
             "cls_name": self.cls_name,
@@ -133,6 +137,12 @@ class TestResult(object):
             "nodes_used": self.nodes_used,
             "services": self.services,
         }
+
+        # Only include node_type if it was specified in the @cluster decorator
+        if self.node_type is not None:
+            result["node_type"] = self.node_type
+
+        return result
 
 
 class TestResults(object):


### PR DESCRIPTION
### Description
Add node_type information to JSON Report only if it is present. This is an additional field addition to a JSON and hence isn't breaking as it is only added when available and in case of heterogeneous clusters.

### Testing
Semaphore Job: https://semaphore.ci.confluent.io/jobs/bbdddff1-7d55-4ca1-bf5f-f43cd8f0aa9f
Results from JSON:
```
"results": [
        {
            "base_results_dir": "/home/semaphore/muckrake/results/2026-03-18--002/",
            "cls_name": "MiniTest",
            "data": null,
            "description": "",
            "function_name": "test",
            "injected_args": null,
            "module_name": "muckrake.tests.mini_test_kraft",
            "node_type": "small",
            "nodes_allocated": 2,
            "nodes_used": 2,
            "relative_results_dir": "MiniTest/test/2/",
            "results_dir": "/home/semaphore/muckrake/results/2026-03-18--002/MiniTest/test/2/",
            "run_time_seconds": 96.54181981086731,
            "services": [],
            "start_time": 1773812559.1935935,
            "stop_time": 1773812655.7354133,
            "summary": "Test Passed",
            "test_id": "muckrake.tests.mini_test_kraft.MiniTest.test",
            "test_status": "PASS"
        },
        {
            "base_results_dir": "/home/semaphore/muckrake/results/2026-03-18--002/",
            "cls_name": "DemoWikipedia",
            "data": null,
            "description": "\nTest automating the cp demo workflow\n    *   create 7 topics \"wikipedia.parsed\", \"wikipedia.parsed.replica\", \"wikipedia.failed\", \"WIKIPEDIABOT\",\n        \"WIKIPEDIANOBOT\", \"EN_WIKIPEDIA_GT_1\", \"EN_WIKIPEDIA_GT_1_COUNTS\"\n    *   create IRC connector\n    *   validate IRC connector\n    *   validate consumer\n    *   create a ksql stream and ksql table\n    *   verify if streams and queries are running\n    *   create persistent ksql queries and verify that they are up and running\n    *   create replicator connector\n    *   validate replicator connector\n    *   create elasticsearch-sink connector\n    *   validate elasticsearch-sink connector\n    *   set mapping for wikipediabot\n    *   set mapping for en_wikipedia_gt_1\n    *   verify if data is written to elasticsearch sink connector\n",
            "function_name": "test_wikipedia_demo",
            "injected_args": null,
            "module_name": "muckrake.tests.demo_wikipedia_test",
            "node_type": "medium",
            "nodes_allocated": 12,
            "nodes_used": 12,
            "relative_results_dir": "DemoWikipedia/test_wikipedia_demo/1/",
            "results_dir": "/home/semaphore/muckrake/results/2026-03-18--002/DemoWikipedia/test_wikipedia_demo/1/",
            "run_time_seconds": 1014.6180176734924,
            "services": [],
            "start_time": 1773812559.1921132,
            "stop_time": 1773813573.8101308,
            "summary": "Test Passed",
            "test_id": "muckrake.tests.demo_wikipedia_test.DemoWikipedia.test_wikipedia_demo",
            "test_status": "PASS"
        }
    ]
```