### PR TITLE
[CPTF-1596] remoteaccount: enable SSH keepalives on paramiko transport

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -31,6 +31,12 @@ from ducktape.utils.http_utils import HttpMixin
 from ducktape.utils.util import wait_until
 
 
+# Interval (in seconds) at which paramiko sends SSH-level MSG_IGNORE keepalives
+# on the cached transport. Chosen well below the typical 60-120s firewall/NAT
+# idle timeout that drops idle TCP on cross-region cloud paths.
+SSH_KEEPALIVE_INTERVAL_SEC = 30
+
+
 def check_ssh(method: Callable) -> Callable:
     def wrapper(self, *args, **kwargs):
         try:
@@ -226,11 +232,10 @@ class RemoteAccount(HttpMixin):
 
         # Send SSH-level keepalives so stateful firewalls / NATs (e.g. cross-region
         # cloud paths) don't drop idle TCP, and so paramiko detects a dead transport
-        # proactively instead of at next exec_command. 30s is well under the typical
-        # 60-120s FW idle timeout.
+        # proactively instead of at next exec_command.
         transport = client.get_transport()
         if transport is not None:
-            transport.set_keepalive(30)
+            transport.set_keepalive(SSH_KEEPALIVE_INTERVAL_SEC)
 
         if self._ssh_client:
             self._ssh_client.close()

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -224,6 +224,14 @@ class RemoteAccount(HttpMixin):
             timeout=self.ssh_config.connecttimeout,
         )
 
+        # Send SSH-level keepalives so stateful firewalls / NATs (e.g. cross-region
+        # cloud paths) don't drop idle TCP, and so paramiko detects a dead transport
+        # proactively instead of at next exec_command. 30s is well under the typical
+        # 60-120s FW idle timeout.
+        transport = client.get_transport()
+        if transport is not None:
+            transport.set_keepalive(30)
+
         if self._ssh_client:
             self._ssh_client.close()
         self._ssh_client = client

--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -31,9 +31,8 @@ from ducktape.utils.http_utils import HttpMixin
 from ducktape.utils.util import wait_until
 
 
-# Interval (in seconds) at which paramiko sends SSH-level MSG_IGNORE keepalives
-# on the cached transport. Chosen well below the typical 60-120s firewall/NAT
-# idle timeout that drops idle TCP on cross-region cloud paths.
+# Below the typical 60-120s firewall/NAT idle timeout that drops idle TCP on
+# cross-region cloud paths.
 SSH_KEEPALIVE_INTERVAL_SEC = 30
 
 
@@ -230,9 +229,8 @@ class RemoteAccount(HttpMixin):
             timeout=self.ssh_config.connecttimeout,
         )
 
-        # Send SSH-level keepalives so stateful firewalls / NATs (e.g. cross-region
-        # cloud paths) don't drop idle TCP, and so paramiko detects a dead transport
-        # proactively instead of at next exec_command.
+        # SSH keepalives: prevent firewall/NAT idle TCP drops and surface dead
+        # transports proactively instead of at next exec_command.
         transport = client.get_transport()
         if transport is not None:
             transport.set_keepalive(SSH_KEEPALIVE_INTERVAL_SEC)


### PR DESCRIPTION
## Summary

Enable paramiko SSH-level keepalives (`MSG_IGNORE` every 30s) on the cached `SSHClient` transport in `RemoteAccount._set_ssh_client`.

## Why

Stateful firewalls and NATs — cross-region cloud paths in particular — silently drop idle TCP after 60–120 s. When a ducktape service sits idle for the bulk of a test (e.g. `MiniKdc` between startup and teardown, or any service that's started early and not interacted with again until much later), the cached paramiko transport's underlying TCP is reset by the firewall. The existing `is_active() / send_ignore()` probe in the `ssh_client` property is one-shot and write-only, so it does not reliably detect the reset before the next `exec_command` surfaces `ECONNRESET`.

`transport.set_keepalive(30)` instructs paramiko to send `MSG_IGNORE` every 30 s. This keeps NAT/FW state warm and surfaces transport death within the interval, at negligible bandwidth cost.

This was hit during cross-region (AWS Oregon driver → IBM Cloud Frankfurt workers, ~150 ms RTT) muckrake system tests, where idle services were being declared unreachable mid-test.

## Issue
https://confluentinc.atlassian.net/browse/CPTF-1596

## Test plan

- [x] Existing ducktape unit tests pass (no behavior change to active SSH paths; only adds a passive heartbeat).
- [x] Long-idle service (e.g. `MiniKdc` held > 5 min) reachable on next `exec_command` without `ECONNRESET`. https://semaphore.ci.confluent.io/jobs/d4f59386-dce3-4af0-82cc-9e40860686aa

🤖 Generated with [Claude Code](https://claude.com/claude-code)