### PR TITLE
[CPTF-1609] Add nested result directory feature to solve OS 255 Byte filename limit 

### DIFF
--- a/docs/run_tests.rst
+++ b/docs/run_tests.rst
@@ -180,8 +180,9 @@ For parameterized tests, each parameter combination gets its own subdirectory un
 ``<test_method_name>``. By default this is a single dotted basename such as
 ``k1=v1.k2=v2.k3=v3``. Pass ``--nested-result-dirs`` to instead nest one directory per
 parameter (``k1=v1/k2=v2/k3=v3/``), sorted by key — useful when the combined args string
-would exceed the OS 255-byte filename limit. ``test_id`` and ``report.json`` are unchanged
-either way.
+would exceed the OS 255-byte filename limit. ``test_id`` and the per-test ``report.json``
+schema are unchanged regardless of the flag; the session-level ``report.json`` gains an
+additive ``nested_result_dirs`` flag.
 
 To see an example of the output structure, go `here`_ and click on one of the details links.
 

--- a/docs/run_tests.rst
+++ b/docs/run_tests.rst
@@ -176,6 +176,13 @@ structured like so::
         ...
 
 
+For parameterized tests, each parameter combination gets its own subdirectory under
+``<test_method_name>``. By default this is a single dotted basename such as
+``k1=v1.k2=v2.k3=v3``. Pass ``--nested-result-dirs`` to instead nest one directory per
+parameter (``k1=v1/k2=v2/k3=v3/``), sorted by key — useful when the combined args string
+would exceed the OS 255-byte filename limit. ``test_id`` and ``report.json`` are unchanged
+either way.
+
 To see an example of the output structure, go `here`_ and click on one of the details links.
 
 .. _here: http://testing.confluent.io/confluent-kafka-system-test-results/

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -93,6 +93,15 @@ def create_ducktape_parser() -> argparse.ArgumentParser:
         "specified will result in new test results being stored in a subdirectory of "
         "this root directory.",
     )
+    parser.add_argument(
+        "--nested-result-dirs",
+        action="store_true",
+        help="lay out per-test result directories with one nested directory per injected "
+        "parameter (e.g. <cls>/<method>/k1=v1/k2=v2/) instead of a single dotted basename "
+        "(<cls>/<method>/k1=v1.k2=v2/). Keeps each path segment short enough to avoid the "
+        "OS 255-byte filename limit for heavily parameterized tests. test_id and report.json "
+        "are unchanged.",
+    )
     parser.add_argument("--exit-first", action="store_true", help="exit after first failure")
     parser.add_argument(
         "--no-teardown",

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -99,8 +99,9 @@ def create_ducktape_parser() -> argparse.ArgumentParser:
         help="lay out per-test result directories with one nested directory per injected "
         "parameter (e.g. <cls>/<method>/k1=v1/k2=v2/) instead of a single dotted basename "
         "(<cls>/<method>/k1=v1.k2=v2/). Keeps each path segment short enough to avoid the "
-        "OS 255-byte filename limit for heavily parameterized tests. test_id and report.json "
-        "are unchanged.",
+        "OS 255-byte filename limit for heavily parameterized tests. test_id and the "
+        "per-test report.json schema are unchanged; the session-level report.json gains an "
+        "additive nested_result_dirs flag.",
     )
     parser.add_argument("--exit-first", action="store_true", help="exit after first failure")
     parser.add_argument(

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -33,6 +33,7 @@ class SessionContext(object):
 
         self.debug = kwargs.get("debug", False)
         self.compress = kwargs.get("compress", False)
+        self.nested_result_dirs = kwargs.get("nested_result_dirs", False)
         self.exit_first = kwargs.get("exit_first", False)
         self.no_teardown = kwargs.get("no_teardown", False)
         self.max_parallel = kwargs.get("max_parallel", 1)

--- a/ducktape/tests/test_context.py
+++ b/ducktape/tests/test_context.py
@@ -187,8 +187,15 @@ class TestContext(object):
             d = os.path.join(d, test_context.cls.__name__)
         if test_context.function is not None:
             d = os.path.join(d, test_context.function.__name__)
-        if test_context.injected_args is not None:
-            d = os.path.join(d, test_context.injected_args_name)
+        if test_context.injected_args:
+            if test_context.session_context.nested_result_dirs:
+                # One nested directory per parameter, sorted by key for stable layout
+                # across reruns and reorderings of @matrix/@parametrize arguments.
+                for k in sorted(test_context.injected_args):
+                    segment = _escape_pathname("%s=%s" % (k, test_context.injected_args[k]))
+                    d = os.path.join(d, segment)
+            else:
+                d = os.path.join(d, test_context.injected_args_name)
         if test_index is not None:
             d = os.path.join(d, str(test_index))
 

--- a/ducktape/tests/test_context.py
+++ b/ducktape/tests/test_context.py
@@ -187,7 +187,7 @@ class TestContext(object):
             d = os.path.join(d, test_context.cls.__name__)
         if test_context.function is not None:
             d = os.path.join(d, test_context.function.__name__)
-        if test_context.injected_args:
+        if test_context.injected_args is not None:
             if test_context.session_context.nested_result_dirs:
                 # One nested directory per parameter, sorted by key for stable layout
                 # across reruns and reorderings of @matrix/@parametrize arguments.

--- a/tests/tests/check_test_context.py
+++ b/tests/tests/check_test_context.py
@@ -106,9 +106,7 @@ class CheckResultsDirLayout(object):
 
     def check_nested_with_test_index(self):
         ctx = self._ctx(injected_args={"a": 1, "b": 2}, nested=True)
-        assert self._suffix(ctx, test_index=3) == os.path.join(
-            "DummyTest", "test_me", "a=1", "b=2", "3"
-        )
+        assert self._suffix(ctx, test_index=3) == os.path.join("DummyTest", "test_me", "a=1", "b=2", "3")
 
     def check_nested_escapes_per_segment(self):
         # Slashes and whitespace inside a value must be sanitized within a single segment,

--- a/tests/tests/check_test_context.py
+++ b/tests/tests/check_test_context.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from ducktape.tests.test import Test
+from ducktape.tests.test_context import TestContext
 from ducktape.services.service import Service
 from ducktape.mark import parametrize
 from ducktape.mark.mark_expander import MarkedFunctionExpander
@@ -45,6 +48,80 @@ class CheckTestContext(object):
 
         # Ensure that each context.services object is a unique reference
         assert len(set(id(ctx.services) for ctx in ctx_list)) == len(ctx_list)
+
+
+class CheckResultsDirLayout(object):
+    """Verify the on-disk layout produced by TestContext.results_dir() in both the legacy
+    flat-basename form and the nested per-parameter form gated by --nested-result-dirs.
+    """
+
+    def _ctx(self, injected_args=None, nested=False):
+        sc = session_context(nested_result_dirs=nested)
+        return TestContext(
+            session_context=sc,
+            file="tests/ducktape_mock.py",
+            module=__name__,
+            cls=DummyTest,
+            function=DummyTest.test_me,
+            cluster=MagicMock(),
+            injected_args=injected_args,
+        )
+
+    def _suffix(self, ctx, test_index=None):
+        """Return the path under the session root."""
+        full = TestContext.results_dir(ctx, test_index)
+        base = ctx.session_context.results_dir
+        return os.path.relpath(full, base)
+
+    def check_flat_default(self):
+        ctx = self._ctx(injected_args={"x": 1, "y": 2}, nested=False)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me", "x=1.y=2")
+
+    def check_flat_preserves_insertion_order(self):
+        # Flat form keeps the historical insertion order (used by test_id/test_name).
+        ctx = self._ctx(injected_args={"b": 1, "a": 2}, nested=False)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me", "b=1.a=2")
+
+    def check_nested_basic(self):
+        ctx = self._ctx(injected_args={"a": 1, "b": 2, "c": 3}, nested=True)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me", "a=1", "b=2", "c=3")
+
+    def check_nested_sorts_keys(self):
+        # Insertion order must not affect on-disk layout when nesting.
+        ctx_in = self._ctx(injected_args={"c": 3, "a": 1, "b": 2}, nested=True)
+        ctx_out = self._ctx(injected_args={"a": 1, "b": 2, "c": 3}, nested=True)
+        assert self._suffix(ctx_in) == self._suffix(ctx_out)
+
+    def check_nested_no_args(self):
+        ctx = self._ctx(injected_args=None, nested=True)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me")
+
+    def check_nested_empty_args(self):
+        ctx = self._ctx(injected_args={}, nested=True)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me")
+
+    def check_nested_single_arg(self):
+        ctx = self._ctx(injected_args={"x": 1}, nested=True)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me", "x=1")
+
+    def check_nested_with_test_index(self):
+        ctx = self._ctx(injected_args={"a": 1, "b": 2}, nested=True)
+        assert self._suffix(ctx, test_index=3) == os.path.join(
+            "DummyTest", "test_me", "a=1", "b=2", "3"
+        )
+
+    def check_nested_escapes_per_segment(self):
+        # Slashes and whitespace inside a value must be sanitized within a single segment,
+        # not allowed to split into extra directory levels.
+        ctx = self._ctx(injected_args={"path": "/etc/foo bar"}, nested=True)
+        # _escape_pathname collapses whitespace and replaces '/' with '.'
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me", "path=.etc.foobar")
+
+    def check_injected_args_name_unaffected_by_flag(self):
+        # The test_id-bearing dotted string must be identical regardless of layout flag.
+        ctx_flat = self._ctx(injected_args={"b": 1, "a": 2}, nested=False)
+        ctx_nest = self._ctx(injected_args={"b": 1, "a": 2}, nested=True)
+        assert ctx_flat.injected_args_name == ctx_nest.injected_args_name == "b=1.a=2"
 
 
 class DummyTest(Test):

--- a/tests/tests/check_test_context.py
+++ b/tests/tests/check_test_context.py
@@ -82,6 +82,17 @@ class CheckResultsDirLayout(object):
         ctx = self._ctx(injected_args={"b": 1, "a": 2}, nested=False)
         assert self._suffix(ctx) == os.path.join("DummyTest", "test_me", "b=1.a=2")
 
+    def check_flat_no_args(self):
+        # injected_args=None must not append any segment under the method dir.
+        ctx = self._ctx(injected_args=None, nested=False)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me")
+
+    def check_flat_empty_args(self):
+        # injected_args={} must also be a no-op (preserves legacy behavior even
+        # though the empty-dict path goes through injected_args_name -> "").
+        ctx = self._ctx(injected_args={}, nested=False)
+        assert self._suffix(ctx) == os.path.join("DummyTest", "test_me")
+
     def check_nested_basic(self):
         ctx = self._ctx(injected_args={"a": 1, "b": 2, "c": 3}, nested=True)
         assert self._suffix(ctx) == os.path.join("DummyTest", "test_me", "a=1", "b=2", "c=3")


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/CPTF-1609

## Summary
- Adds opt-in `--nested-result-dirs` CLI flag. When set, `TestContext.results_dir()` produces one nested directory per `@matrix`/`@parametrize` argument (`<cls>/<method>/k1=v1/k2=v2/`) instead of the single dotted basename (`<cls>/<method>/k1=v1.k2=v2/`).
- Default behavior unchanged; `test_id`, `test_name`, and `report.json` schema preserved regardless of the flag.
- Keeps each path segment short enough to avoid the OS 255-byte filename limit hit by heavily-parameterized tests (e.g. `ConsumerProtocolMigrationTest::test_consumer_offline_migration` on kafka `8.3.x` / `master`).

## Test plan
- [x] Unit tests in `tests/tests/check_test_context.py` covering flat default, nested basic, sorted-key stability, no/empty/single args, `test_index` placement, per-segment escaping, and `injected_args_name` flag-independence.
- [x] End-to-end verified via muckrake branch-builder against the offending parameterization (a separate muckrake-infra change consumes the flag).
https://semaphore.ci.confluent.io/workflows/9bae5628-810f-40ce-b640-37c5f56c62fe?pipeline_id=747fc6da-e239-4376-83a5-4406bcf8b2e5

Design one-pager: https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/5600575730

🤖 Generated with [Claude Code](https://claude.com/claude-code)