### PR TITLE
[CPTF-1633] Add --ignore-node-type flag to bypass heterogeneous node matching

### DIFF
--- a/docs/test_clusters.rst
+++ b/docs/test_clusters.rst
@@ -71,3 +71,16 @@ Backward Compatibility
 - Tests without ``node_type`` will match **any available node**
 - Existing tests and cluster configurations continue to work unchanged
 - Node type is optional in both test annotations and cluster configuration
+
+Ignoring Node Types
+-------------------
+
+Pass ``--ignore-node-type`` on the command line to ignore the ``node_type`` requested by
+tests and allocate any available node of the matching operating system::
+
+    ducktape --ignore-node-type ./my_tests_dir
+
+This lets tests written for a heterogeneous cluster run on a homogeneous one without editing
+their annotations. The requested number of nodes and operating system are still honored; only
+the ``node_type`` hint is dropped. It applies to both ``@cluster(node_type=...)`` and an
+explicit ``cluster_spec``.

--- a/ducktape/cluster/cluster_spec.py
+++ b/ducktape/cluster/cluster_spec.py
@@ -91,6 +91,13 @@ class ClusterSpec(object):
         """
         return ClusterSpec(self.nodes.clone())
 
+    def without_node_types(self):
+        """
+        Returns a copy of this spec with all node_type requirements cleared, so that each node
+        spec matches any available node of its operating system.
+        """
+        return ClusterSpec([NodeSpec(node_spec.operating_system) for node_spec in self.nodes])
+
     def __str__(self):
         node_spec_to_num = {}
         for node_spec in self.nodes.elements():

--- a/ducktape/command_line/parse_args.py
+++ b/ducktape/command_line/parse_args.py
@@ -188,6 +188,13 @@ def create_ducktape_parser() -> argparse.ArgumentParser:
         "or cluster_spec=ClusterSpec.empty()",
     )
     parser.add_argument(
+        "--ignore-node-type",
+        action="store_true",
+        help="Ignore the node_type specified in @cluster decorators (or cluster_spec) and allocate "
+        "any available node of the matching OS. Useful for running tests written for a heterogeneous "
+        "cluster on a homogeneous one.",
+    )
+    parser.add_argument(
         "--test-runner-timeout",
         action="store",
         type=int,

--- a/ducktape/tests/session.py
+++ b/ducktape/tests/session.py
@@ -40,6 +40,7 @@ class SessionContext(object):
         self.default_expected_num_nodes = kwargs.get("default_num_nodes", None)
         self.fail_bad_cluster_utilization = kwargs.get("fail_bad_cluster_utilization")
         self.fail_greedy_tests = kwargs.get("fail_greedy_tests", False)
+        self.ignore_node_type = kwargs.get("ignore_node_type", False)
         self.test_runner_timeout = kwargs.get("test_runner_timeout")
         self.enable_jvm_logs = kwargs.get("enable_jvm_logs", False)
         self._globals = kwargs.get("globals")

--- a/ducktape/tests/test_context.py
+++ b/ducktape/tests/test_context.py
@@ -222,10 +222,11 @@ class TestContext(object):
         cluster_spec = self.cluster_use_metadata.get(CLUSTER_SPEC_KEYWORD)
         cluster_size = self.cluster_use_metadata.get(CLUSTER_SIZE_KEYWORD)
         node_type = self.cluster_use_metadata.get(CLUSTER_NODE_TYPE_KEYWORD)
+        ignore_node_type = self.session_context.ignore_node_type if self.session_context else False
         if cluster_spec is not None:
-            return cluster_spec
+            return cluster_spec.without_node_types() if ignore_node_type else cluster_spec
         elif cluster_size is not None:
-            return ClusterSpec.simple_linux(cluster_size, node_type)
+            return ClusterSpec.simple_linux(cluster_size, None if ignore_node_type else node_type)
         elif not self.cluster:
             return ClusterSpec.empty()
         elif self.session_context.fail_greedy_tests:

--- a/tests/mark/check_cluster_use_metadata.py
+++ b/tests/mark/check_cluster_use_metadata.py
@@ -66,6 +66,44 @@ class CheckClusterUseAnnotation(object):
         assert len(test_context_list) == 1
         assert test_context_list[0].expected_num_nodes == num_nodes
 
+    def check_node_type_preserved_by_default(self):
+        num_nodes = 5
+
+        @cluster(num_nodes=num_nodes, node_type="large")
+        def function():
+            return "hi"
+
+        test_context_list = MarkedFunctionExpander(function=function).expand()
+        spec = test_context_list[0].expected_cluster_spec
+        assert spec.size() == num_nodes
+        assert all(node.node_type == "large" for node in spec.nodes.elements())
+
+    def check_ignore_node_type_strips_num_nodes_type(self):
+        num_nodes = 5
+
+        @cluster(num_nodes=num_nodes, node_type="large")
+        def function():
+            return "hi"
+
+        session_context = ducktape_mock.session_context(ignore_node_type=True)
+        test_context_list = MarkedFunctionExpander(function=function, session_context=session_context).expand()
+        spec = test_context_list[0].expected_cluster_spec
+        assert spec.size() == num_nodes
+        assert all(node.node_type is None for node in spec.nodes.elements())
+
+    def check_ignore_node_type_strips_cluster_spec_type(self):
+        num_nodes = 5
+
+        @cluster(cluster_spec=ClusterSpec.simple_linux(num_nodes, "large"))
+        def function():
+            return "hi"
+
+        session_context = ducktape_mock.session_context(ignore_node_type=True)
+        test_context_list = MarkedFunctionExpander(function=function, session_context=session_context).expand()
+        spec = test_context_list[0].expected_cluster_spec
+        assert spec.size() == num_nodes
+        assert all(node.node_type is None for node in spec.nodes.elements())
+
     @pytest.mark.parametrize("fail_greedy_tests", [True, False])
     @pytest.mark.parametrize("has_annotation", [True, False])
     def check_empty_cluster_annotation(self, fail_greedy_tests, has_annotation):


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/CPTF-1633

Adds `--ignore-node-type` to ignore the `node_type` from `@cluster(node_type=...)` / `cluster_spec` and allocate any available node of the matching OS — lets tests written for a heterogeneous cluster run on a homogeneous one. Node count and OS are still honored; defaults to off, so existing behavior is unchanged.

Stripping happens at `TestContext.expected_cluster_spec`, the single spec both allocation and scheduling read, so behavior stays consistent. 

Docs updated; 3 unit tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
