### PR TITLE
[CPTF-1662] Report all tests on driver abort, join clients in parallel

### DIFF
--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -48,7 +48,7 @@ from ducktape.tests.test_context import TestContext
 from ducktape.utils.terminal_size import get_terminal_size
 
 DEFAULT_MP_JOIN_TIMEOUT = 30
-DEFAULT_TIMEOUT_EXCEPTION_JOIN_TIMEOUT = 120
+DEFAULT_TIMEOUT_EXCEPTION_JOIN_TIMEOUT = 300
 
 
 class Receiver(object):
@@ -162,21 +162,39 @@ class TestRunner(object):
 
     def _join_test_process(self, process_key, timeout: int = DEFAULT_MP_JOIN_TIMEOUT):
         # waits for process to complete, if it doesn't terminate it
-        process: multiprocessing.Process = self._client_procs[process_key]
-        start = time.time()
-        while time.time() - start <= timeout:
-            if not process.is_alive():
-                self.client_report[process_key]["status"] = "FINISHED"
-                break
-            time.sleep(0.1)
-        else:
-            # Note: This can lead to some tmp files being uncleaned, otherwise nothing else should be executed by the
-            #       client after this point.
+        self._join_test_processes([process_key], timeout)
+
+    def _join_test_processes(self, process_keys, timeout: int = DEFAULT_MP_JOIN_TIMEOUT):
+        """Same as _join_test_process, but the timeout is one budget shared by the whole batch."""
+        pending = [key for key in process_keys if key in self._client_procs]
+        deadline = time.time() + timeout
+        while pending and time.time() <= deadline:
+            pending = [key for key in pending if self._client_procs[key].is_alive()]
+            if pending:
+                time.sleep(0.1)
+
+        for key in pending:
+            # Note: This can lead to some tmp files being uncleaned, otherwise nothing else should be
+            #       executed by the client after this point.
             self._log(
-                logging.ERROR, f"after waiting {timeout}s, process {process.name} failed to complete.  Terminating..."
+                logging.ERROR,
+                f"after waiting {timeout}s, process {self._client_procs[key].name} failed to complete.  "
+                f"Terminating...",
             )
+
+        for key in process_keys:
+            if key in self._client_procs:
+                self._reap_test_process(key)
+
+    def _reap_test_process(self, process_key):
+        # kills the process if it's still running, then records its outcome
+        process: multiprocessing.Process = self._client_procs[process_key]
+        if process.is_alive():
             self._terminate_process(process)
             self.client_report[process_key]["status"] = "TERMINATED"
+        else:
+            self.client_report[process_key]["status"] = "FINISHED"
+        # join is unbounded so exitcode is always reaped, see #370/#416
         process.join()
         self.client_report[process_key]["exitcode"] = process.exitcode
         self.client_report[process_key]["runner_end_time"] = time.time()
@@ -301,7 +319,7 @@ class TestRunner(object):
                 del self._test_cluster[test_key]
 
             tc = self._test_context[test_key.test_id]
-            msg = f"Test timed out: {reason}"
+            msg = f"Test aborted: {reason}"
             self._log(logging.ERROR, f"{tc.test_id}: {msg}")
 
             start_time = self.client_report[test_key].get("runner_start_time", stop_time)
@@ -319,6 +337,30 @@ class TestRunner(object):
 
         # Clear active tests since we've reported them all as failed
         self.active_tests.clear()
+
+    def _abort_run(self, reason):
+        """Tear down all client processes and report everything that did not get to finish."""
+        try:
+            # SIGTERM lets clients collect logs and tear down, and stops them sending to a dead driver
+            for process_key in list(self._client_procs.keys()):
+                proc = self._client_procs[process_key]
+                if proc.is_alive():
+                    self._log(logging.INFO, f"Sending SIGTERM to process {proc.name} for graceful shutdown")
+                    os.kill(proc.pid, signal.SIGTERM)
+
+            self._join_test_processes(list(self._client_procs.keys()), self.timeout_exception_join_timeout)
+        except Exception:
+            self._log(logging.ERROR, f"Failed to shut down client processes\n{traceback.format_exc(limit=16)}")
+        finally:
+            self._client_procs = {}
+
+        self._report_active_as_failed(reason)
+        self._report_remaining_as_failed(reason)
+
+        try:
+            self.receiver.close()
+        except Exception:
+            self._log(logging.ERROR, f"Failed to close receiver\n{traceback.format_exc(limit=16)}")
 
     def run_all_tests(self):
         self.receiver.start()
@@ -361,48 +403,15 @@ class TestRunner(object):
                     try:
                         event = self.receiver.recv(timeout=self.session_context.test_runner_timeout)
                         self._handle(event)
-                    except TimeoutError as e:
-                        # Handle timeout gracefully - clean up, mark tests as failed, and return results
-                        err_str = "Timeout error while receiving message: %s: %s" % (
-                            str(type(e)),
-                            str(e),
-                        )
-                        err_str += "\n" + traceback.format_exc(limit=16)
-                        self._log(logging.ERROR, err_str)
-
-                        # Send SIGTERM to all client processes immediately to allow graceful cleanup
-                        # (copy logs, run teardown, etc.)
-                        for process_key in list(self._client_procs.keys()):
-                            proc = self._client_procs[process_key]
-                            if proc.is_alive():
-                                self._log(logging.INFO, f"Sending SIGTERM to process {proc.name} for graceful shutdown")
-                                os.kill(proc.pid, signal.SIGTERM)
-
-                        # Wait for processes to shutdown gracefully (in parallel), escalate to SIGKILL if needed
-                        for process_key in list(self._client_procs.keys()):
-                            self._join_test_process(process_key, self.timeout_exception_join_timeout)
-                        self._client_procs = {}
-                        # Mark active tests as failed with the exception message
-                        self._report_active_as_failed(str(e))
-
-                        # Mark all remaining tests as failed with the exception message
-                        self._report_remaining_as_failed(str(e))
-
-                        self.receiver.close()
-                        return self.results
                     except Exception as e:
-                        # For all other exceptions, clean up and re-raise
-                        err_str = "Exception receiving message: %s: %s" % (
-                            str(type(e)),
-                            str(e),
-                        )
+                        # the driver can no longer reach its clients, so salvage a report over raising
+                        reason = "%s: %s" % (type(e).__name__, e)
+                        err_str = "Aborting run, failed to receive message: %s" % reason
                         err_str += "\n" + traceback.format_exc(limit=16)
                         self._log(logging.ERROR, err_str)
 
-                        for proc in list(self._client_procs):
-                            self._join_test_process(proc, self.finish_join_timeout)
-                        self._client_procs = {}
-                        raise
+                        self._abort_run(reason)
+                        return self.results
             except KeyboardInterrupt:
                 # If SIGINT is received, stop triggering new tests, and let the currently running tests finish
                 self._log(
@@ -413,9 +422,11 @@ class TestRunner(object):
 
         # All clients should be cleaned up in their finish block
         if self._client_procs:
-            self._log(logging.WARNING, f"Some clients failed to clean up, waiting 10min to join: {self._client_procs}")
-        for proc in list(self._client_procs):
-            self._join_test_process(proc, self.finish_join_timeout)
+            self._log(
+                logging.WARNING,
+                f"Some clients failed to clean up, waiting {self.finish_join_timeout}s to join: {self._client_procs}",
+            )
+        self._join_test_processes(list(self._client_procs), self.finish_join_timeout)
 
         self.receiver.close()
 

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -340,17 +340,21 @@ class TestRunner(object):
 
     def _abort_run(self, reason):
         """Tear down all client processes and report everything that did not get to finish."""
-        try:
-            # SIGTERM lets clients collect logs and tear down, and stops them sending to a dead driver
-            for process_key in list(self._client_procs.keys()):
-                proc = self._client_procs[process_key]
+        # SIGTERM lets clients collect logs and tear down, and stops them sending to a dead driver
+        for process_key in list(self._client_procs.keys()):
+            proc = self._client_procs[process_key]
+            # a client dying between is_alive() and the signal must not skip the rest
+            try:
                 if proc.is_alive():
                     self._log(logging.INFO, f"Sending SIGTERM to process {proc.name} for graceful shutdown")
                     os.kill(proc.pid, signal.SIGTERM)
+            except Exception:
+                self._log(logging.ERROR, f"Failed to signal process {proc.name}\n{traceback.format_exc(limit=16)}")
 
+        try:
             self._join_test_processes(list(self._client_procs.keys()), self.timeout_exception_join_timeout)
         except Exception:
-            self._log(logging.ERROR, f"Failed to shut down client processes\n{traceback.format_exc(limit=16)}")
+            self._log(logging.ERROR, f"Failed to join client processes\n{traceback.format_exc(limit=16)}")
         finally:
             self._client_procs = {}
 

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -608,7 +608,7 @@ class CheckRunner(object):
         assert len(results_list) == 1
         result = results_list[0]
         assert result.test_status == FAIL
-        assert f"Test timed out: {reason}" in result.summary
+        assert f"Test aborted: {reason}" in result.summary
         assert result.start_time < result.stop_time
 
         # Active tests should be cleared
@@ -786,6 +786,135 @@ class CheckRunner(object):
 
         assert runner.finish_join_timeout == 10
         assert runner.timeout_exception_join_timeout == 60
+
+    def check_runner_aborts_gracefully_on_non_timeout_error(self):
+        """A corrupt message must be salvaged the same way a timeout is, not raised."""
+        import pickle
+
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context(max_parallel=1000)
+
+        test_methods = [TestThingy.test_delayed, TestThingy.test_failure]
+        ctx_list = self._do_expand(
+            test_file=TEST_THINGY_FILE,
+            test_class=TestThingy,
+            test_methods=test_methods,
+            cluster=mock_cluster,
+            session_context=session_context,
+        )
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
+        runner.timeout_exception_join_timeout = 5
+
+        err = pickle.UnpicklingError("invalid load key, '\\x01'.")
+        with patch.object(runner.receiver, "recv", side_effect=err):
+            results = runner.run_all_tests()
+
+        assert not runner._client_procs
+        assert len(results) == 2
+        assert results.num_failed == 2
+        assert results.num_passed == 0
+        for result in results:
+            assert result.test_status == FAIL
+            assert "UnpicklingError" in result.summary
+            assert "invalid load key" in result.summary
+
+    def check_abort_reports_even_if_client_shutdown_fails(self):
+        """A failure tearing down clients must not stop the report from being produced."""
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context()
+        ctx_list = self._do_expand(
+            test_file=TEST_THINGY_FILE,
+            test_class=TestThingy,
+            test_methods=[TestThingy.test_pi, TestThingy.test_failure],
+            cluster=mock_cluster,
+            session_context=session_context,
+        )
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
+
+        with patch.object(runner.receiver, "close"), patch.object(
+            runner, "_join_test_processes", side_effect=RuntimeError("cannot join")
+        ):
+            runner._abort_run("SomeError: driver died")
+
+        assert not runner._client_procs
+        assert len(runner.results) == 2
+        assert runner.results.num_failed == 2
+
+    def check_join_test_processes_shares_one_deadline(self):
+        """Joining N stuck processes must cost one timeout, not N timeouts."""
+        import time
+
+        from ducktape.tests.runner import TestKey
+
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context()
+        ctx_list = self._do_expand(
+            test_file=TEST_THINGY_FILE,
+            test_class=TestThingy,
+            test_methods=[TestThingy.test_pi],
+            cluster=mock_cluster,
+            session_context=session_context,
+        )
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
+
+        # none of these exit on their own, so the batch has to hit the deadline
+        keys = []
+        for i in range(5):
+            key = TestKey("stuck.test.%d" % i, i)
+            proc = Mock()
+            # alive until it is killed and joined
+            state = {"joined": False}
+            proc.is_alive.side_effect = lambda state=state: not state["joined"]
+            proc.join.side_effect = lambda *a, state=state, **k: state.__setitem__("joined", True)
+            proc.pid = os.getpid() + 1000 + i
+            proc.name = "StuckProcess-%d" % i
+            proc.exitcode = -9
+            runner._client_procs[key] = proc
+            keys.append(key)
+
+        timeout = 2
+        with patch.object(runner, "_terminate_process"):
+            start = time.time()
+            runner._join_test_processes(keys, timeout)
+            elapsed = time.time() - start
+
+        # sequential joins would have taken 5 * timeout
+        assert elapsed < timeout * 2, f"expected a shared deadline, took {elapsed:.1f}s"
+        assert not runner._client_procs
+        for key in keys:
+            assert runner.client_report[key]["status"] == "TERMINATED"
+
+    def check_reap_records_exitcode_after_terminate(self):
+        """Terminated processes must still be joined so exitcode reaches the report."""
+        from ducktape.tests.runner import TestKey
+
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context()
+        ctx_list = self._do_expand(
+            test_file=TEST_THINGY_FILE,
+            test_class=TestThingy,
+            test_methods=[TestThingy.test_pi],
+            cluster=mock_cluster,
+            session_context=session_context,
+        )
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
+
+        key = TestKey("stuck.test", 0)
+        proc = Mock()
+        # alive until terminated, dead once joined
+        proc.is_alive.side_effect = [True, False]
+        proc.pid = os.getpid() + 1000
+        proc.name = "StuckProcess"
+        proc.exitcode = -9
+        runner._client_procs[key] = proc
+
+        with patch.object(runner, "_terminate_process"):
+            runner._reap_test_process(key)
+
+        proc.join.assert_called_once_with()
+        assert runner.client_report[key]["status"] == "TERMINATED"
+        assert runner.client_report[key]["exitcode"] == -9
+        assert key not in runner._client_procs
 
 
 class ShrinkingLocalhostCluster(LocalhostCluster):

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -840,6 +840,53 @@ class CheckRunner(object):
         assert len(runner.results) == 2
         assert runner.results.num_failed == 2
 
+    def check_abort_joins_remaining_clients_when_a_signal_fails(self):
+        """A client that dies before its SIGTERM must not stop the others being joined."""
+        from ducktape.tests.runner import TestKey
+
+        mock_cluster = LocalhostCluster(num_nodes=1000)
+        session_context = tests.ducktape_mock.session_context()
+        ctx_list = self._do_expand(
+            test_file=TEST_THINGY_FILE,
+            test_class=TestThingy,
+            test_methods=[TestThingy.test_pi],
+            cluster=mock_cluster,
+            session_context=session_context,
+        )
+        runner = TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
+        runner.timeout_exception_join_timeout = 5
+
+        keys = []
+        for i in range(3):
+            key = TestKey("client.test.%d" % i, i)
+            proc = Mock()
+            proc.is_alive.return_value = False
+            proc.pid = os.getpid() + 1000 + i
+            proc.name = "Process-%d" % i
+            proc.exitcode = 0
+            runner._client_procs[key] = proc
+            keys.append(key)
+
+        # the first one races: alive when checked, gone by the time it is signalled
+        raced = {"checked": False}
+
+        def alive_once():
+            if not raced["checked"]:
+                raced["checked"] = True
+                return True
+            return False
+
+        runner._client_procs[keys[0]].is_alive.side_effect = alive_once
+
+        with patch.object(runner.receiver, "close"), patch(
+            "ducktape.tests.runner.os.kill", side_effect=ProcessLookupError("no such process")
+        ):
+            runner._abort_run("SomeError: driver died")
+
+        assert not runner._client_procs
+        for key in keys:
+            assert runner.client_report[key]["exitcode"] == 0
+
     def check_join_test_processes_shares_one_deadline(self):
         """Joining N stuck processes must cost one timeout, not N timeouts."""
         import time

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -1,0 +1,44 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from ducktape.tests.runner import Receiver
+
+
+@pytest.fixture(autouse=True)
+def destroy_receiver_contexts():
+    """Destroy the zmq context of every Receiver built during a test.
+
+    A TestRunner that is built but never run leaves its context bound with an open socket, and
+    only run_all_tests() closes it. Collecting such a context later blocks forever in
+    Context.term(), which stalls whichever unrelated test happens to trigger the collection.
+    """
+    receivers = []
+    real_init = Receiver.__init__
+
+    def tracking_init(receiver, *args, **kwargs):
+        real_init(receiver, *args, **kwargs)
+        receivers.append(receiver)
+
+    with patch.object(Receiver, "__init__", tracking_init):
+        yield
+
+    for receiver in receivers:
+        try:
+            receiver.zmq_context.destroy(linger=0)
+        except Exception:
+            pass


### PR DESCRIPTION
### Description
The driver only handled `TimeoutError` from the client socket gracefully — every other failure re-raised and discarded the entire test report, so a run that died partway through was published as green with the missing tests simply absent rather than failed. Any failure receiving or handling a client message now shuts the run down the same way a timeout does: signal the clients so they can tear down and collect logs, mark the tests that were still running or had not yet started as failed, and return a complete report. 

Because the clients are now always signalled, they also stop blocking on sends to a driver that is no longer listening, which previously aborted their teardown and lost log collection. Separately, the driver now waits on all client processes against a single shared deadline instead of one at a time, since sequential waiting made shutdown cost the timeout multiplied by the number of stuck clients; the shared timeout is raised from 120s to 300s because it is now a total budget rather than per-process.

Also included is a test-only fixture that destroys each `Receiver`'s zmq context after every test under `tests/runner`. A `TestRunner` that is built but never run leaves its context bound with an open socket, and garbage collecting one later blocks forever in `Context.term()` — stalling whichever unrelated test happens to trigger the collection. This was already latent on master and was hanging CI non-deterministically. Verified on Linux with the fork start method across Python 3.11, 3.12 and 3.13.

### Issue
Jira: https://confluentinc.atlassian.net/browse/CPTF-1662
Jira: https://confluentinc.atlassian.net/browse/CPTF-1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)
