### PR TITLE
[CPTF-1671] Record the test's own node count in driver-built results

### DIFF
--- a/ducktape/tests/result.py
+++ b/ducktape/tests/result.py
@@ -41,15 +41,21 @@ class TestResult(object):
         data=None,
         start_time=-1,
         stop_time=-1,
+        nodes_allocated=None,
+        nodes_used=None,
     ):
         """
-        @param test_context  standard test context object
-        @param test_status   did the test pass or fail, etc?
-        @param summary       summary information
-        @param data          data returned by the test, e.g. throughput
+        @param test_context     standard test context object
+        @param test_status      did the test pass or fail, etc?
+        @param summary          summary information
+        @param data             data returned by the test, e.g. throughput
+        @param nodes_allocated  node count, defaulting to the size of the test's cluster. The driver must
+                                pass this explicitly, since its test_context holds the whole cluster
+                                rather than the subcluster allocated to the test.
+        @param nodes_used       as above, for the peak node count
         """
-        self.nodes_allocated = len(test_context.cluster)
-        self.nodes_used = test_context.cluster.max_used_nodes
+        self.nodes_allocated = len(test_context.cluster) if nodes_allocated is None else nodes_allocated
+        self.nodes_used = test_context.cluster.max_used_nodes if nodes_used is None else nodes_used
 
         # Collect node_type from cluster metadata if available
         self.node_type = test_context.cluster_use_metadata.get("node_type")

--- a/ducktape/tests/runner.py
+++ b/ducktape/tests/runner.py
@@ -263,6 +263,8 @@ class TestRunner(object):
                 summary=msg,
                 start_time=time.time(),
                 stop_time=time.time(),
+                nodes_allocated=tc.expected_num_nodes,
+                nodes_used=0,
             )
             self.results.append(result)
             result.report()
@@ -294,6 +296,8 @@ class TestRunner(object):
                 summary=msg,
                 start_time=time.time(),
                 stop_time=time.time(),
+                nodes_allocated=tc.expected_num_nodes,
+                nodes_used=0,
             )
             self.results.append(result)
             result.report()
@@ -312,13 +316,15 @@ class TestRunner(object):
         )
         stop_time = time.time()
         for test_key in active_test_keys:
+            tc = self._test_context[test_key.test_id]
+            nodes_allocated = tc.expected_num_nodes
             if hasattr(self, "_test_cluster") and test_key in self._test_cluster:
                 subcluster = self._test_cluster[test_key]
+                nodes_allocated = len(subcluster)
                 # Return nodes to the cluster and remove tracking entry
                 self.cluster.free(subcluster.nodes)
                 del self._test_cluster[test_key]
 
-            tc = self._test_context[test_key.test_id]
             msg = f"Test aborted: {reason}"
             self._log(logging.ERROR, f"{tc.test_id}: {msg}")
 
@@ -331,6 +337,9 @@ class TestRunner(object):
                 summary=msg,
                 start_time=start_time,
                 stop_time=stop_time,
+                nodes_allocated=nodes_allocated,
+                # the test was running and held its nodes, but the driver can't see the client's peak
+                nodes_used=nodes_allocated,
             )
             self.results.append(result)
             result.report()

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -632,7 +632,6 @@ class CheckRunner(object):
 
         # Simulate an active test with allocated cluster
         from ducktape.tests.runner import TestKey
-        from ducktape.cluster.finite_subcluster import FiniteSubcluster
         import time
 
         test_ctx = ctx_list[0]
@@ -697,7 +696,6 @@ class CheckRunner(object):
         """Test that duplicate FINISHED messages are handled correctly with three distinct cases."""
         from ducktape.tests.runner import TestKey
         from ducktape.tests.result import TestResult
-        from ducktape.cluster.finite_subcluster import FiniteSubcluster
         import time
 
         mock_cluster = LocalhostCluster(num_nodes=1000)

--- a/tests/runner/check_runner.py
+++ b/tests/runner/check_runner.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ducktape.cluster.finite_subcluster import FiniteSubcluster
 from ducktape.cluster.node_container import NodeContainer, InsufficientResourcesError
 from ducktape.tests.runner_client import RunnerClient
 from ducktape.tests.status import PASS, FAIL
@@ -962,6 +963,77 @@ class CheckRunner(object):
         assert runner.client_report[key]["status"] == "TERMINATED"
         assert runner.client_report[key]["exitcode"] == -9
         assert key not in runner._client_procs
+
+    def _various_num_nodes_runner(self, test_methods, num_nodes=100):
+        mock_cluster = LocalhostCluster(num_nodes=num_nodes)
+        session_context = tests.ducktape_mock.session_context()
+        ctx_list = self._do_expand(
+            test_file=VARIOUS_NUM_NODES_TEST_FILE,
+            test_class=VariousNumNodesTest,
+            test_methods=test_methods,
+            cluster=mock_cluster,
+            session_context=session_context,
+        )
+        return mock_cluster, TestRunner(mock_cluster, session_context, Mock(), ctx_list, 1)
+
+    def check_remaining_as_failed_records_declared_node_count(self):
+        """Unrun tests must record their own num_nodes, not the size of the whole cluster."""
+        _, runner = self._various_num_nodes_runner(
+            [VariousNumNodesTest.test_three_nodes_a, VariousNumNodesTest.test_five_nodes_a]
+        )
+
+        runner._report_remaining_as_failed("driver died")
+
+        by_name = {r.test_id.split(".")[-1]: r for r in runner.results}
+        assert by_name["test_three_nodes_a"].nodes_allocated == 3
+        assert by_name["test_five_nodes_a"].nodes_allocated == 5
+        for result in runner.results:
+            assert result.nodes_used == 0
+
+    def check_unschedulable_records_declared_node_count(self):
+        """Unschedulable tests must record their own num_nodes, not the size of the whole cluster."""
+        _, runner = self._various_num_nodes_runner([VariousNumNodesTest.test_five_nodes_a], num_nodes=2)
+
+        runner._report_unschedulable(runner.scheduler.filter_unschedulable_tests())
+
+        assert len(runner.results) == 1
+        result = list(runner.results)[0]
+        assert result.nodes_allocated == 5
+        assert result.nodes_used == 0
+
+    def check_active_as_failed_records_subcluster_node_count(self):
+        """Aborted tests must record the size of their subcluster, not of the whole cluster."""
+        from ducktape.tests.runner import TestKey
+
+        mock_cluster, runner = self._various_num_nodes_runner([VariousNumNodesTest.test_three_nodes_a])
+
+        test_ctx = runner.scheduler.peek()
+        runner._preallocate_subcluster(test_ctx)
+        test_key = TestKey(test_ctx.test_id, runner.test_counter)
+        runner.active_tests[test_key] = True
+
+        runner._report_active_as_failed("driver died")
+
+        assert len(runner.results) == 1
+        result = list(runner.results)[0]
+        assert result.nodes_allocated == 3, "should be the subcluster size, not len(cluster)"
+        assert result.nodes_used == 3
+        # the subcluster must still have been returned to the cluster
+        assert mock_cluster.num_available_nodes() == 100
+
+    def check_client_built_result_still_uses_its_cluster(self):
+        """Results built without overrides keep deriving counts from their own test_context.cluster."""
+        from ducktape.tests.result import TestResult
+
+        mock_cluster, runner = self._various_num_nodes_runner([VariousNumNodesTest.test_three_nodes_a])
+        test_ctx = runner.scheduler.peek()
+        subcluster = FiniteSubcluster(mock_cluster.alloc(test_ctx.expected_cluster_spec))
+        test_ctx.cluster = subcluster
+
+        result = TestResult(test_ctx, 1, runner.session_context, test_status=FAIL, summary="x")
+
+        assert result.nodes_allocated == 3
+        assert result.nodes_used == subcluster.max_used_nodes
 
 
 class ShrinkingLocalhostCluster(LocalhostCluster):


### PR DESCRIPTION
### Description
When the driver builds a `TestResult` itself — because a test never started, was still running when the run aborted, or the whole run is unschedulable — it used the driver's own `test_context`, whose `.cluster` is the entire cluster rather than the subcluster allocated to that test. `TestResult` derives `nodes_allocated` and `nodes_used` from `len(test_context.cluster)`, so every driver-fabricated result recorded the full cluster size instead of the test's declared node count. In a 200-node run this showed up as a test declaring `@cluster(num_nodes=8)` reporting `nodes_allocated=200`, and it corrupts anything that sizes clusters from historical reports — muckrake's node optimizer read that value as the test's requirement and provisioned 155 pods for a single 8-node test.

`TestResult` now accepts optional `nodes_allocated`/`nodes_used` overrides, defaulting to the existing behavior so client-built results are unaffected. The three driver paths pass explicit values: the subcluster size (falling back to the test's declared node count if none was allocated yet) for a test that was actively running, and the declared node count with `nodes_used=0` for tests that never ran at all.

### Issue
Jira: https://confluentinc.atlassian.net/browse/CPTF-1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
