### PR TITLE
[CPTF-1718] Switch OS to ubuntu24 for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
 


### PR DESCRIPTION
### Description
Switch OS to ubuntu24 for readthedocs as the build fails with older version.

### Testing
Passing build: https://app.readthedocs.org/projects/ducktape/builds/?version__slug=latest